### PR TITLE
Encode to a DOM document

### DIFF
--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -27,6 +27,7 @@ $xml = xml_encode($data, utf8(), pretty_print());
 
 The encoding components consist out of following functions
 
+- [document_encode](#document_encode): Encodes an array into a DOM [Document](dom.md).
 - [typed](#typed): Decodes an XML string into a defined well-typed shape.
 - [xml_decode](#xml_decode): Decodes an XML string into an array
 - [xml_encode](#xml_encode): Encodes an array into an XML string
@@ -34,6 +35,30 @@ The encoding components consist out of following functions
 More information about [the PHP format can be found here](#php-format).
 
 ## Functions
+
+#### document_encode
+
+The `document_encode` function transforms an array into a DOM [Document](dom.md).
+This way, you can make some changes before transforming it ack to an XML string.
+
+```php
+use function VeeWee\Xml\Dom\Configurator\pretty_print;
+use function VeeWee\Xml\Dom\Configurator\utf8;
+use function VeeWee\Xml\Encoding\document_encode;
+
+$doc = document_encode(['hello' => 'world'], utf8(), pretty_print());
+
+// Do whatever DOM manipulation you want before transforming it back to an XML string.
+
+```
+
+The first argument is the data structure.
+The component does data normalization for you so that you can pass in any custom types like iterables, json serializable objects, ...
+
+Besides the data, you can apply any [DOM configurator](dom.md#configurators) you please.
+In the example above, we tell the DOM document to be UTF8 and pretty printed.
+
+More information about [the PHP format can be found here](#php-format).
 
 #### xml_decode
 

--- a/src/Xml/Encoding/document_encode.php
+++ b/src/Xml/Encoding/document_encode.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Encoding;
+
+use DOMDocument;
+use VeeWee\Xml\Dom\Document;
+use VeeWee\Xml\Encoding\Exception\EncodingException;
+use function VeeWee\Xml\Encoding\Internal\Encoder\Builder\normalize_data;
+use function VeeWee\Xml\Encoding\Internal\Encoder\Builder\root;
+use function VeeWee\Xml\Encoding\Internal\wrap_exception;
+
+/**
+ * @param list<callable(DOMDocument): DOMDocument> $configurators
+ *
+ * @throws EncodingException
+ */
+function document_encode(array $data, callable ... $configurators): Document
+{
+    return wrap_exception(
+        static function () use ($data, $configurators): Document {
+            $doc = Document::configure(...$configurators);
+            $doc->build(
+                root(
+                    normalize_data($data)
+                )
+            );
+
+            return $doc;
+        }
+    );
+}

--- a/src/Xml/Encoding/xml_encode.php
+++ b/src/Xml/Encoding/xml_encode.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace VeeWee\Xml\Encoding;
 
 use DOMDocument;
-use VeeWee\Xml\Dom\Document;
 use VeeWee\Xml\Encoding\Exception\EncodingException;
-use function VeeWee\Xml\Encoding\Internal\Encoder\Builder\normalize_data;
-use function VeeWee\Xml\Encoding\Internal\Encoder\Builder\root;
 use function VeeWee\Xml\Encoding\Internal\wrap_exception;
 
 /**
@@ -20,14 +17,7 @@ function xml_encode(array $data, callable ... $configurators): string
 {
     return wrap_exception(
         static function () use ($data, $configurators): string {
-            $doc = Document::configure(...$configurators);
-            $doc->build(
-                root(
-                    normalize_data($data)
-                )
-            );
-
-            return $doc->toXmlString();
+            return document_encode($data, ...$configurators)->toXmlString();
         }
     );
 }

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -64,6 +64,7 @@ require_once __DIR__.'/Xml/Encoding/Internal/Encoder/Builder/normalize_data.php'
 require_once __DIR__.'/Xml/Encoding/Internal/Encoder/Builder/parent_node.php';
 require_once __DIR__.'/Xml/Encoding/Internal/Encoder/Builder/root.php';
 require_once __DIR__.'/Xml/Encoding/Internal/wrap_exception.php';
+require_once __DIR__.'/Xml/Encoding/document_encode.php';
 require_once __DIR__.'/Xml/Encoding/typed.php';
 require_once __DIR__.'/Xml/Encoding/xml_decode.php';
 require_once __DIR__.'/Xml/Encoding/xml_encode.php';

--- a/tests/Xml/Encoding/EncodingTest.php
+++ b/tests/Xml/Encoding/EncodingTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use VeeWee\Xml\Encoding\Exception\EncodingException;
 use VeeWee\Xml\Encoding\XmlSerializable;
 use function Psl\Fun\identity;
+use function VeeWee\Xml\Encoding\document_encode;
 use function VeeWee\Xml\Encoding\xml_decode;
 use function VeeWee\Xml\Encoding\xml_encode;
 
@@ -22,6 +23,16 @@ final class EncodingTest extends TestCase
     {
         $actual = xml_encode($data, identity());
         static::assertXmlStringEqualsXmlString($xml, $actual);
+    }
+
+    /**
+     * @dataProvider provideBidirectionalCases
+     * @dataProvider provideEncodingOnly
+     */
+    public function test_it_encodes_to_document(string $xml, array $data)
+    {
+        $actual = document_encode($data, identity());
+        static::assertXmlStringEqualsXmlString($xml, $actual->toXmlString());
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Similar to the the `xml_encode` document, this component encodes an array into a document.
This way you can manipulate or convert it to whatever output you want:

```php
$doc = document_encode(['hello' => 'world'], utf8(), pretty_print());

// Do whatever DOM manipulation you want before transforming it back to an XML string.

// E.g. Use it in an XSLT template
```
