### PR TITLE
Add replace by external nodes dom manipulator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-xsl": "*",
         "ext-xmlreader": "*",
         "ext-xmlwriter": "*",
-        "azjezz/psl": "^1.3",
+        "azjezz/psl": "^1.5",
         "webmozart/assert": "^1.9",
         "thecodingmachine/safe": "^1.3"
     },

--- a/docs/dom.md
+++ b/docs/dom.md
@@ -655,6 +655,16 @@ use function VeeWee\Xml\Dom\Manipulator\Node\replace_by_external_node;
 $copiedNode = replace_by_external_node($documentNode, $externalNode);
 ```
 
+#### replace_by_external_nodes
+
+Makes it possible to replace a `DOMNode` from the current document with a list of `DOMNode` from an external document.
+
+```php
+use function VeeWee\Xml\Dom\Manipulator\Node\replace_by_external_nodes;
+
+$copiedNode = replace_by_external_nodes($documentNode, $externalNodes);
+```
+
 ## Mappers
 
 Converts the DOM document to something else.

--- a/src/Xml/Dom/Manipulator/Node/replace_by_external_nodes.php
+++ b/src/Xml/Dom/Manipulator/Node/replace_by_external_nodes.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Dom\Manipulator\Node;
+
+use DOMNode;
+use VeeWee\Xml\Exception\RuntimeException;
+use Webmozart\Assert\Assert;
+use function get_class;
+use function Psl\Dict\map;
+use function VeeWee\Xml\ErrorHandling\disallow_issues;
+
+/**
+ * @throws RuntimeException
+ * @param iterable<array-key, DOMNode> $sources
+ * @return array<array-key, DOMNode>
+ */
+function replace_by_external_nodes(DOMNode $target, iterable $sources): array
+{
+    return disallow_issues(
+        /**
+         * @return array<array-key, DOMNode>
+         */
+        static function () use ($target, $sources) : array {
+            $parentNode = $target->parentNode;
+            Assert::notNull($parentNode, 'Could not replace a node without parent node. ('.get_class($target).')');
+            $copies = map(
+                $sources,
+                static fn (DOMNode $source): DOMNode => import_node_deeply($target, $source)
+            );
+
+            foreach ($copies as $copy) {
+                $parentNode->insertBefore($copy, $target);
+            }
+
+            $parentNode->removeChild($target);
+
+            return $copies;
+        }
+    );
+}

--- a/src/Xml/Encoding/Internal/Encoder/Builder/element.php
+++ b/src/Xml/Encoding/Internal/Encoder/Builder/element.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace VeeWee\Xml\Encoding\Internal\Encoder\Builder;
 
 use DOMElement;
+use Psl\Exception\InvariantViolationException;
 use Psl\Type\Exception\AssertException;
 use function Psl\Dict\filter_keys;
 use function Psl\Dict\map_with_key;
@@ -28,6 +29,7 @@ use function VeeWee\Xml\Dom\Builder\namespaced_element as namespacedElementBuild
  * @return callable(DOMElement): DOMElement
  *
  * @throws AssertException
+ * @throws InvariantViolationException
  */
 function element(string $name, array $data): callable
 {

--- a/src/Xml/Encoding/Internal/Encoder/Builder/is_node_list.php
+++ b/src/Xml/Encoding/Internal/Encoder/Builder/is_node_list.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Encoding\Internal\Encoder\Builder;
 
+use Psl\Exception\InvariantViolationException;
 use function Psl\Type\dict;
 use function Psl\Type\int;
 use function Psl\Type\mixed;
 
 /**
  * @psalm-internal VeeWee\Xml\Encoding
+ * @throws InvariantViolationException
  */
 function is_node_list(array $data): bool
 {

--- a/src/Xml/Encoding/Internal/Encoder/Builder/parent_node.php
+++ b/src/Xml/Encoding/Internal/Encoder/Builder/parent_node.php
@@ -6,6 +6,7 @@ namespace VeeWee\Xml\Encoding\Internal\Encoder\Builder;
 
 use DOMElement;
 use DOMNode;
+use Psl\Exception\InvariantViolationException;
 use Psl\Type\Exception\AssertException;
 use function VeeWee\Xml\Dom\Builder\children as buildChildren;
 use function VeeWee\Xml\Dom\Builder\element as elementBuilder;
@@ -18,6 +19,7 @@ use function VeeWee\Xml\Dom\Builder\escaped_value;
  * @return callable(DOMNode): DOMElement
  *
  * @throws AssertException
+ * @throws InvariantViolationException
  */
 function parent_node(string $name, array|string $data): callable
 {

--- a/src/Xml/Encoding/Internal/Encoder/Builder/root.php
+++ b/src/Xml/Encoding/Internal/Encoder/Builder/root.php
@@ -6,6 +6,7 @@ namespace VeeWee\Xml\Encoding\Internal\Encoder\Builder;
 
 use DOMDocument;
 use DOMNode;
+use Psl\Exception\InvariantViolationException;
 use VeeWee\Xml\Encoding\Exception\EncodingException;
 use function Psl\Dict\map_with_key;
 use function VeeWee\Xml\Dom\Builder\nodes;
@@ -15,6 +16,7 @@ use function VeeWee\Xml\Dom\Builder\nodes;
  * @return callable(DOMDocument): list<DOMNode>
  *
  * @throws EncodingException
+ * @throws InvariantViolationException
  */
 function root(array $data): callable
 {

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -35,6 +35,7 @@ require_once __DIR__.'/Xml/Dom/Locator/elements_with_tagname.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/Node/append_external_node.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/Node/import_node_deeply.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/Node/replace_by_external_node.php';
+require_once __DIR__.'/Xml/Dom/Manipulator/Node/replace_by_external_nodes.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/append.php';
 require_once __DIR__.'/Xml/Dom/Mapper/xml_string.php';
 require_once __DIR__.'/Xml/Dom/Mapper/xslt_template.php';

--- a/tests/Xml/Dom/Manipulator/Node/ReplaceByExternalNodesTest.php
+++ b/tests/Xml/Dom/Manipulator/Node/ReplaceByExternalNodesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Dom\Manipulator\Node;
+
+use DOMDocument;
+use DOMElement;
+use PHPUnit\Framework\TestCase;
+use VeeWee\Xml\Exception\RuntimeException;
+use function VeeWee\Xml\Dom\Locator\Node\children;
+use function VeeWee\Xml\Dom\Manipulator\Node\replace_by_external_nodes;
+
+final class ReplaceByExternalNodesTest extends TestCase
+{
+    public function test_it_can_replace_a_node(): void
+    {
+        $source = new DOMDocument();
+        $source->loadXML('<hello />');
+        $target = new DOMDocument();
+        $target->loadXML('<world />');
+
+        $results = replace_by_external_nodes($target->documentElement, [$source->documentElement]);
+        $result = $results[0];
+
+        static::assertInstanceOf(DOMElement::class, $result);
+        static::assertSame('hello', $result->nodeName);
+        static::assertXmlStringEqualsXmlString($target->saveXML(), $source->saveXML());
+    }
+
+    public function test_it_can_replace_many_nodes(): void
+    {
+        $source = new DOMDocument();
+        $source->loadXML('<hello><world /><toon /></hello>');
+        $target = new DOMDocument();
+        $target->loadXML('<hello><items /></hello>');
+        $items = children($source->documentElement);
+
+        $results = replace_by_external_nodes($target->documentElement->childNodes->item(0), $items);
+
+        static::assertInstanceOf(DOMElement::class, $results[0]);
+        static::assertSame('world', $results[0]->nodeName);
+        static::assertInstanceOf(DOMElement::class, $results[1]);
+        static::assertSame('toon', $results[1]->nodeName);
+
+        static::assertXmlStringEqualsXmlString($target->saveXML(), $source->saveXML());
+    }
+
+    public function test_it_can_not_replace_a_document_into_a_document(): void
+    {
+        $source = new DOMDocument();
+        $source->loadXML('<hello />');
+        $target = new DOMDocument();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not replace a node without parent node. (DOMDocument)');
+        replace_by_external_nodes($target, [$source]);
+    }
+
+    
+    public function test_it_can_recursively_replace_a_node_with_another_external_node(): void
+    {
+        $source = new DOMDocument();
+        $source->loadXML('<hello><world><name>VeeWee</name></world></hello>');
+        $target = new DOMDocument();
+        $target->loadXML('<hello></hello>');
+        $expected = new DOMDocument();
+        $expected->loadXML('<world><name>VeeWee</name></world>');
+
+        $results = replace_by_external_nodes($target->documentElement, [$source->documentElement->firstChild]);
+        $result = $results[0];
+
+        static::assertInstanceOf(DOMElement::class, $result);
+        static::assertSame('world', $result->nodeName);
+        static::assertXmlStringEqualsXmlString($expected->saveXML(), $target->saveXML());
+    }
+}


### PR DESCRIPTION


|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Provides a new way to replace one dom node with multiple dom nodes.
(Handy for xml flatterning in xsd and wsdl)
