### PR TITLE
Optimize duplicate namespaces on root

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="phpunit" version="^9.5.10" installed="9.5.10" location="./tools/phpunit.phar" copy="true"/>
-  <phar name="psalm" version="^4.12.0" installed="4.12.0" location="./tools/psalm.phar" copy="true"/>
+  <phar name="psalm" version="^4.15.0" installed="4.15.0" location="./tools/psalm.phar" copy="true"/>
   <phar name="infection" version="^0.25" installed="0.25.3" location="./tools/infection.phar" copy="true"/>
   <phar name="php-cs-fixer" version="^3.3.2" installed="3.3.2" location="./tools/php-cs-fixer.phar" copy="true"/>
 </phive>

--- a/tests/Xml/Dom/Configurator/OptimizeNamespacesTest.php
+++ b/tests/Xml/Dom/Configurator/OptimizeNamespacesTest.php
@@ -45,5 +45,29 @@ final class OptimizeNamespacesTest extends TestCase
             </foo>
             EOXML,
         ];
+        yield 'duplicate-namespaced-and-root-xmlns-on-root' => [
+            <<<EOXML
+            <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/store1">
+                <xsd:include schemaLocation="./store1.xsd" />
+            </schema>
+            EOXML,
+            <<<EOXML
+            <ns1:schema xmlns:ns1="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/store1">
+                <ns1:include schemaLocation="./store1.xsd"/>
+            </ns1:schema>
+            EOXML,
+        ];
+        yield 'duplicate-namespaced-and-root-xmlns-on-child' => [
+            <<<EOXML
+            <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/store1">
+                <xsd:include xmlns:xsd="http://www.w3.org/2001/XMLSchema" schemaLocation="./store1.xsd" />
+            </schema>
+            EOXML,
+            <<<EOXML
+            <ns1:schema xmlns:ns1="http://www.w3.org/2001/XMLSchema" targetNamespace="http://soapinterop.org/store1">
+                <ns1:include schemaLocation="./store1.xsd"/>
+            </ns1:schema>
+            EOXML,
+        ];
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues |

#### Summary

When the root element contains a duplicate named and root namespace, the optimization process failed.


```xml
<schema
    xmlns="http://www.w3.org/2001/XMLSchema"
    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
    targetNamespace="http://soapinterop.org/store1"
>
    <xsd:include schemaLocation="./store1.xsd" />
</schema>
```

This PR will result in:

```xml
<ns1:schem
    xmlns:ns1="http://www.w3.org/2001/XMLSchema"
    targetNamespace="http://soapinterop.org/store1"
>
    <ns1:include schemaLocation="./store1.xsd"/>
</ns1:schema>
```
