### PR TITLE
Introduce copy_named_xmlns_attributes

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -860,6 +860,35 @@ $doc->manipulate(
 );
 ```
 
+### Element
+
+Element specific manipulators operate on `DOMElement` instances.
+
+#### copy_named_xmlns_attributes
+
+Makes it possible to copy all names xmlns attributes from one element to an other element.
+
+```php
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Manipulator\Element\copy_named_xmlns_attributes;
+
+$doc = Document::fromXmlString(
+    <<<EOXML
+    <root>
+        <a xmlns:foo="http://foo" />
+        <b />
+    </root>
+    EOXML
+);
+
+$a = $doc->xpath()->querySingle('//a');
+$b = $doc->xpath()->querySingle('//b');
+
+copy_named_xmlns_attributes($b, $a);
+
+// > $b will contain xmlns:foo="http://foo"
+```
+
 ### Node
 
 Node specific manipulators operate on `DOMNode` instances.

--- a/src/Xml/Dom/Manipulator/Element/copy_named_xmlns_attributes.php
+++ b/src/Xml/Dom/Manipulator/Element/copy_named_xmlns_attributes.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Dom\Manipulator\Element;
+
+use DOMElement;
+use DOMNameSpaceNode;
+use VeeWee\Xml\Exception\RuntimeException;
+use function VeeWee\Xml\Dom\Builder\xmlns_attribute;
+use function VeeWee\Xml\Dom\Locator\Xmlns\linked_namespaces;
+
+/**
+ * @throws RuntimeException
+ */
+function copy_named_xmlns_attributes(DOMElement $target, DOMElement $source): void
+{
+    linked_namespaces($source)->forEach(static function (DOMNameSpaceNode $xmlns) use ($target) {
+        if ($xmlns->prefix && !$target->hasAttribute($xmlns->nodeName)) {
+            xmlns_attribute($xmlns->prefix, $xmlns->namespaceURI)($target);
+        }
+    });
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -48,6 +48,7 @@ require_once __DIR__.'/Xml/Dom/Locator/elements_with_tagname.php';
 require_once __DIR__.'/Xml/Dom/Locator/root_namespace.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/Attribute/rename.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/Document/optimize_namespaces.php';
+require_once __DIR__.'/Xml/Dom/Manipulator/Element/copy_named_xmlns_attributes.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/Element/rename.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/Node/append_external_node.php';
 require_once __DIR__.'/Xml/Dom/Manipulator/Node/import_node_deeply.php';

--- a/tests/Xml/Dom/Manipulator/Element/CopyNamedXmlnsAttributesTest.php
+++ b/tests/Xml/Dom/Manipulator/Element/CopyNamedXmlnsAttributesTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Dom\Manipulator\Element;
+
+use PHPUnit\Framework\TestCase;
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Manipulator\Element\copy_named_xmlns_attributes;
+use function VeeWee\Xml\Dom\Mapper\xml_string;
+use function VeeWee\Xml\Dom\Xpath\Configurator\namespaces;
+
+final class CopyNamedXmlnsAttributesTest extends TestCase
+{
+    public function test_it_can_copy_names_xmlns_attributes_in_the_same_doc(): void
+    {
+        $doc = Document::fromXmlString(
+            <<<EOXML
+            <root>
+                <a xmlns:foo="http://foo" />
+                <b />
+            </root>
+            EOXML
+        );
+
+        $a = $doc->xpath()->querySingle('//a');
+        $b = $doc->xpath()->querySingle('//b');
+
+        copy_named_xmlns_attributes($b, $a);
+
+        static::assertXmlStringEqualsXmlString('<b xmlns:foo="http://foo" />', xml_string()($b));
+    }
+
+    public function test_it_does_not_copy_root_xmlns(): void
+    {
+        $doc = Document::fromXmlString(
+            <<<EOXML
+            <root>
+                <a xmlns="http://foo" />
+                <b />
+            </root>
+            EOXML
+        );
+
+        $a = $doc->xpath(namespaces(['a' => "http://foo"]))->querySingle('//a:a');
+        $b = $doc->xpath()->querySingle('//b');
+
+        copy_named_xmlns_attributes($b, $a);
+
+        static::assertXmlStringEqualsXmlString('<b />', xml_string()($b));
+    }
+
+    public function test_it_does_not_overwrite_the_same_name(): void
+    {
+        $doc = Document::fromXmlString(
+            <<<EOXML
+            <root>
+                <a xmlns:foo="http://foo" />
+                <b xmlns:foo="http://bar" />
+            </root>
+            EOXML
+        );
+
+        $a = $doc->xpath()->querySingle('//a');
+        $b = $doc->xpath()->querySingle('//b');
+
+        copy_named_xmlns_attributes($b, $a);
+
+        static::assertXmlStringEqualsXmlString('<b xmlns:foo="http://bar" />', xml_string()($b));
+    }
+
+    public function test_it_can_do_many_namespaces_as_well(): void
+    {
+        $doc = Document::fromXmlString(
+            <<<EOXML
+            <root>
+                <a xmlns:foo="http://foo" xmlns:bar="http://bar" xmlns:baz="http://baz" />
+                <b />
+            </root>
+            EOXML
+        );
+
+        $a = $doc->xpath()->querySingle('//a');
+        $b = $doc->xpath()->querySingle('//b');
+
+        copy_named_xmlns_attributes($b, $a);
+
+        static::assertXmlStringEqualsXmlString('<b xmlns:foo="http://foo" xmlns:bar="http://bar" xmlns:baz="http://baz" />', xml_string()($b));
+    }
+
+    public function test_it_does_not_include_internally_added_namespaces(): void
+    {
+        $doc = Document::fromXmlString(
+            <<<EOXML
+            <root>
+                <a xmlns:foo="http://foo">
+                    <barbaz xmlns:bar="http://bar" xmlns:baz="http://baz" />
+                </a>
+                <b />
+            </root>
+            EOXML
+        );
+
+        $a = $doc->xpath()->querySingle('//a');
+        $b = $doc->xpath()->querySingle('//b');
+
+        copy_named_xmlns_attributes($b, $a);
+
+        static::assertXmlStringEqualsXmlString('<b xmlns:foo="http://foo" />', xml_string()($b));
+    }
+
+    public function test_it_can_copy_cross_docs(): void
+    {
+        $doc1 = Document::fromXmlString(
+            <<<EOXML
+            <root>
+                <a xmlns:foo="http://foo">
+                    <barbaz xmlns:bar="http://bar" xmlns:baz="http://baz" />
+                </a>
+            </root>
+            EOXML
+        );
+        $doc2 = Document::fromXmlString(
+            <<<EOXML
+            <root>
+                <b />
+            </root>
+            EOXML
+        );
+
+        $a = $doc1->xpath()->querySingle('//a');
+        $b = $doc2->xpath()->querySingle('//b');
+
+        copy_named_xmlns_attributes($b, $a);
+
+        static::assertXmlStringEqualsXmlString('<b xmlns:foo="http://foo" />', xml_string()($b));
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

```php
use VeeWee\Xml\Dom\Document;
use function VeeWee\Xml\Dom\Manipulator\Element\copy_named_xmlns_attributes;

$doc = Document::fromXmlString(
    <<<EOXML
    <root>
        <a xmlns:foo="http://foo" />
        <b />
    </root>
    EOXML
);

$a = $doc->xpath()->querySingle('//a');
$b = $doc->xpath()->querySingle('//b');

copy_named_xmlns_attributes($b, $a);

// > $b will contain xmlns:foo="http://foo"
```
