### PR TITLE
Add failing test for decoding falsy values

### DIFF
--- a/tests/Xml/Encoding/EncodingTest.php
+++ b/tests/Xml/Encoding/EncodingTest.php
@@ -266,6 +266,24 @@ final class EncodingTest extends TestCase
             'xml' => '<hello><![CDATA[Jos & Bos]]></hello>',
             'data' => ['hello' => 'Jos & Bos']
         ];
+        yield 'falsy values' => [
+            'xml' => <<<EOXML
+                <root>
+                   <zero>0</zero>
+                   <one>1</one>
+                   <empty-string />
+                   <string>string</string>
+                </root>
+            EOXML,
+            'data' => [
+                'root' => [
+                    'zero' => '0',
+                    'one' => '1',
+                    'empty-string' => '',
+                    'string' => 'string',
+                ]
+            ]
+        ];
     }
 
     public function provideInvalidXml()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | Maybe
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

I don't know exactly how to fix this but I reproduced an issue when decoding falsy values.
I would expect
```xml
<root>
   <zero>0</zero>
   <one>1</one>
   <empty-string />
   <string>string</string>
</root>
```
to be decoded as 
```php
[
    'root' => [
        'zero' => '0',
        'one' => '1',
        'empty-string' => '',
        'string' => 'string',
    ]
]
```
but actually I get
```php
[
    'root' => [
        'one' => '1',
        'string' => 'string',
    ]
]
```

My guess is that the `filter`s in `element` and `grouped_children` should be removed but there could be side effects.

Let me know if I can help somehow.
