### PR TITLE
Improve decoding and encoding falsy values

### DIFF
--- a/src/Xml/Encoding/Internal/Decoder/Builder/element.php
+++ b/src/Xml/Encoding/Internal/Decoder/Builder/element.php
@@ -31,7 +31,8 @@ function element(DOMElement $element): array
                 $namespaces,
                 $attributes,
                 $children ?: ['@value' => $element->textContent]
-            )
+            ),
+            static fn (mixed $data): bool => $data !== []
         )
     ];
 }

--- a/src/Xml/Encoding/Internal/Decoder/Builder/grouped_children.php
+++ b/src/Xml/Encoding/Internal/Decoder/Builder/grouped_children.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace VeeWee\Xml\Encoding\Internal\Decoder\Builder;
 
 use DOMElement;
-use function Psl\Dict\filter;
 use function Psl\Dict\map;
 use function Psl\Dict\merge;
 use function Psl\Iter\reduce_with_keys;
@@ -16,25 +15,23 @@ use function Psl\Iter\reduce_with_keys;
  */
 function grouped_children(DOMElement $element): array
 {
-    return filter(
-        reduce_with_keys(
-            group_child_elements($element),
-            /**
-             * @param array $children
-             * @param DOMElement|list<DOMElement> $child
-             * @return array
-             */
-            static fn (array $children, string $name, DOMElement|array $child): array
-                => merge(
-                    $children,
-                    [
-                        $name => is_array($child)
-                            ? [...map($child, static fn (DOMElement $child): array|string
-                                => unwrap_element(element($child)))]
-                            : unwrap_element(element($child))
-                    ]
-                ),
-            [],
-        )
+    return reduce_with_keys(
+        group_child_elements($element),
+        /**
+         * @param array $children
+         * @param DOMElement|list<DOMElement> $child
+         * @return array
+         */
+        static fn (array $children, string $name, DOMElement|array $child): array
+            => merge(
+                $children,
+                [
+                    $name => is_array($child)
+                        ? [...map($child, static fn (DOMElement $child): array|string
+                            => unwrap_element(element($child)))]
+                        : unwrap_element(element($child))
+                ]
+            ),
+        [],
     );
 }

--- a/src/Xml/Encoding/Internal/Encoder/Builder/element.php
+++ b/src/Xml/Encoding/Internal/Encoder/Builder/element.php
@@ -48,7 +48,7 @@ function element(string $name, array $data): callable
     $children = filter_nulls([
         $attributes ? attributes($attributes) : null,
         $namedNamespaces ? xmlns_attributes($namedNamespaces) : null,
-        $value ? escaped_value($value) : null,
+        $value !== null ? escaped_value($value) : null,
         ...values(map_with_key(
             $element,
             /**

--- a/tests/Xml/Encoding/EncodingTest.php
+++ b/tests/Xml/Encoding/EncodingTest.php
@@ -44,6 +44,7 @@ final class EncodingTest extends TestCase
      * @dataProvider provideBidirectionalCases
      * @dataProvider provideRiskyBidirectionalCases
      * @dataProvider provideDecodingOnly
+     * @dataProvider provideRiskyDecodingOnly
      */
     public function test_it_decodes(string $xml, array $data)
     {
@@ -108,6 +109,7 @@ final class EncodingTest extends TestCase
                     'default' => 'world',
                     'value' => 'Toon',
                 ],
+                '@value' => ''
             ]]
         ];
         yield 'nested-single-child' => [
@@ -169,6 +171,45 @@ final class EncodingTest extends TestCase
                             'category' => ['M', 'N', 'O']
                         ]
                     ]
+                ]
+            ]
+        ];
+        yield 'falsy values' => [
+            'xml' => <<<EOXML
+                <root>
+                   <zero>0</zero>
+                   <one>1</one>
+                   <empty-string />
+                   <string>string</string>
+                   <attributes attr1="val1">0</attributes>
+                   <empty-attributes attr1="val1" />
+                   <falsy-attributes attr1="0" />
+                </root>
+            EOXML,
+            'data' => [
+                'root' => [
+                    'zero' => '0',
+                    'one' => '1',
+                    'empty-string' => '',
+                    'string' => 'string',
+                    'attributes' => [
+                        '@attributes' => [
+                            'attr1' => 'val1',
+                        ],
+                        '@value' => '0',
+                    ],
+                    'empty-attributes' => [
+                        '@attributes' => [
+                            'attr1' => 'val1',
+                        ],
+                        '@value' => '',
+                    ],
+                    'falsy-attributes' => [
+                        '@attributes' => [
+                            'attr1' => '0',
+                        ],
+                        '@value' => '',
+                    ],
                 ]
             ]
         ];
@@ -266,23 +307,81 @@ final class EncodingTest extends TestCase
             'xml' => '<hello><![CDATA[Jos & Bos]]></hello>',
             'data' => ['hello' => 'Jos & Bos']
         ];
-        yield 'falsy values' => [
+    }
+
+    public function provideRiskyDecodingOnly()
+    {
+        yield 'falsy namespaced' => [
             'xml' => <<<EOXML
                 <root>
-                   <zero>0</zero>
-                   <one>1</one>
-                   <empty-string />
-                   <string>string</string>
+                   <a xmlns="http://a" attr1="val1" />
+                   <b xmlns="http://b" attr1="val1">0</b>
+                   <x:c xmlns:x="http://x" attr1="val1" />
+                   <x:d xmlns:x="http://x" attr1="val1">0</x:d>
+                   <c xmlns="http://c" attr1="val1" />
+                   <c xmlns="http://c" attr1="val1">0</c>
                 </root>
             EOXML,
             'data' => [
                 'root' => [
-                    'zero' => '0',
-                    'one' => '1',
-                    'empty-string' => '',
-                    'string' => 'string',
+                    'a' => [
+                        '@namespaces' => [
+                            '' => 'http://a',
+                        ],
+                        '@attributes' => [
+                            'attr1' => 'val1',
+                        ],
+                        '@value' => '',
+                    ],
+                    'b' => [
+                        '@namespaces' => [
+                            '' => 'http://b',
+                        ],
+                        '@attributes' => [
+                            'attr1' => 'val1',
+                        ],
+                        '@value' => '0',
+                    ],
+                    'x:c' => [
+                        '@namespaces' => [
+                            'x' => 'http://x',
+                        ],
+                        '@attributes' => [
+                            'attr1' => 'val1',
+                        ],
+                        '@value' => '',
+                    ],
+                    'x:d' => [
+                        '@namespaces' => [
+                            'x' => 'http://x',
+                        ],
+                        '@attributes' => [
+                            'attr1' => 'val1',
+                        ],
+                        '@value' => '0',
+                    ],
+                    'c' => [
+                        [
+                            '@namespaces' => [
+                                '' => 'http://c',
+                            ],
+                            '@attributes' => [
+                                'attr1' => 'val1',
+                            ],
+                            '@value' => '',
+                        ],
+                        [
+                            '@namespaces' => [
+                                '' => 'http://c',
+                            ],
+                            '@attributes' => [
+                                'attr1' => 'val1',
+                            ],
+                            '@value' => '0',
+                        ],
+                    ]
                 ]
-            ]
+            ],
         ];
     }
 

--- a/tests/Xml/Encoding/EncodingTest.php
+++ b/tests/Xml/Encoding/EncodingTest.php
@@ -266,6 +266,24 @@ final class EncodingTest extends TestCase
             'xml' => '<hello><![CDATA[Jos & Bos]]></hello>',
             'data' => ['hello' => 'Jos & Bos']
         ];
+        yield 'falsy values' => [
+            'xml' => <<<EOXML
+                <root>
+                   <zero>0</zero>
+                   <one>1</one>
+                   <empty-string />
+                   <string>string</string>
+                </root>
+            EOXML,
+            'data' => [
+                'root' => [
+                    'zero' => '0',
+                    'one' => '1',
+                    'empty-string' => '',
+                    'string' => 'string',
+                ]
+            ]
+        ];
     }
 
     public function provideInvalidXml()


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #28


#### Summary


I would expect
```xml
<root>
   <zero>0</zero>
   <one>1</one>
   <empty-string />
   <string>string</string>
</root>
```
to be decoded as 
```php
[
    'root' => [
        'zero' => '0',
        'one' => '1',
        'empty-string' => '',
        'string' => 'string',
    ]
]
```
but actually I get
```php
[
    'root' => [
        'one' => '1',
        'string' => 'string',
    ]
]
```


This PR fixes that, and some other small issues during encoding / decoding.
