### PR TITLE
Support callables on main classes again

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -25,7 +25,7 @@ $doc = Document::configure(
     Configurator\validator(
         Validator\internal_xsd_validator()
     ),
-    static fn (DOMDocument $document) => (new MyCustomMergeImportsConfigurator())($document),
+    new MyCustomMergeImportsConfigurator(),
 );
 
 $xpath = $doc->xpath(

--- a/src/Xml/Dom/Collection/NodeList.php
+++ b/src/Xml/Dom/Collection/NodeList.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Dom\Collection;
 
-use Closure;
 use Countable;
 use DOMElement;
 use DOMNode;
@@ -104,19 +103,19 @@ final class NodeList implements Countable, IteratorAggregate
 
     /**
      * @template R
-     * @param \Closure(T): R $mapper
+     * @param callable(T): R $mapper
      *
      * @return list<R>
      */
-    public function map(Closure $mapper): array
+    public function map(callable $mapper): array
     {
-        return map($this->nodes, $mapper);
+        return map($this->nodes, $mapper(...));
     }
 
     /**
-     * @param \Closure(T): void $mapper
+     * @param callable(T): void $mapper
      */
-    public function forEach(Closure $mapper): void
+    public function forEach(callable $mapper): void
     {
         foreach ($this->nodes as $node) {
             $mapper($node);
@@ -125,27 +124,27 @@ final class NodeList implements Countable, IteratorAggregate
 
     /**
      * @template X of DOMNode
-     * @param \Closure(T): iterable<X> $mapper
+     * @param callable(T): iterable<X> $mapper
      *
      * @return NodeList<X>
      */
-    public function detect(Closure $mapper): self
+    public function detect(callable $mapper): self
     {
         return new self(
             ...flat_map(
                 $this->nodes,
-                $mapper
+                $mapper(...)
             )
         );
     }
 
     /**
-     * @param \Closure(T): bool $predicate
+     * @param callable(T): bool $predicate
      * @return NodeList<T>
      */
-    public function filter(Closure $predicate): self
+    public function filter(callable $predicate): self
     {
-        return new self(...filter($this->nodes, $predicate));
+        return new self(...filter($this->nodes, $predicate(...)));
     }
 
     /**
@@ -162,21 +161,21 @@ final class NodeList implements Countable, IteratorAggregate
 
     /**
      * @template R
-     * @param \Closure(R, T): R $reducer
+     * @param callable(R, T): R $reducer
      * @param R $initial
      * @return R
      */
-    public function reduce(Closure $reducer, mixed $initial): mixed
+    public function reduce(callable $reducer, mixed $initial): mixed
     {
-        return reduce($this->nodes, $reducer, $initial);
+        return reduce($this->nodes, $reducer(...), $initial);
     }
 
     /**
-     * @param list<\Closure(DOMXPath): DOMXPath> $configurators
+     * @param list<callable(DOMXPath): DOMXPath> $configurators
      * @throws RuntimeException
      * @return NodeList<DOMNode>
      */
-    public function query(string $xpath, Closure ... $configurators): self
+    public function query(string $xpath, callable ... $configurators): self
     {
         return $this->detect(
             /**
@@ -190,11 +189,11 @@ final class NodeList implements Countable, IteratorAggregate
 
     /**
      * @template X
-     * @param list<\Closure(DOMXPath): DOMXPath> $configurators
+     * @param list<callable(DOMXPath): DOMXPath> $configurators
      * @param TypeInterface<X> $type
      * @return list<X>
      */
-    public function evaluate(string $expression, TypeInterface $type, Closure ... $configurators): array
+    public function evaluate(string $expression, TypeInterface $type, callable ... $configurators): array
     {
         return $this->map(
             static fn (DOMNode $node): mixed
@@ -269,12 +268,12 @@ final class NodeList implements Countable, IteratorAggregate
     }
 
     /**
-     * @param \Closure(T, T): int $sorter
+     * @param callable(T, T): int $sorter
      *
      * @return NodeList<T>
      */
-    public function sort(Closure $sorter): self
+    public function sort(callable $sorter): self
     {
-        return new self(...sort($this->nodes, $sorter));
+        return new self(...sort($this->nodes, $sorter(...)));
     }
 }

--- a/src/Xml/Dom/Xpath.php
+++ b/src/Xml/Dom/Xpath.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Dom;
 
-use Closure;
 use DOMNode;
 use DOMXPath;
 use InvalidArgumentException;
@@ -25,9 +24,9 @@ final class Xpath
     }
 
     /**
-     * @param list<\Closure(DOMXPath): DOMXPath> $configurators
+     * @param list<callable(DOMXPath): DOMXPath> $configurators
      */
-    public static function fromDocument(Document $document, Closure ... $configurators): self
+    public static function fromDocument(Document $document, callable ... $configurators): self
     {
         return new self(
             configure(...$configurators)(new DOMXPath($document->toUnsafeDocument()))
@@ -35,11 +34,11 @@ final class Xpath
     }
 
     /**
-     * @param list<\Closure(DOMXPath): DOMXPath> $configurators
+     * @param list<callable(DOMXPath): DOMXPath> $configurators
      * @throws RuntimeException
      * @throws InvalidArgumentException
      */
-    public static function fromUnsafeNode(DOMNode $node, Closure ... $configurators): self
+    public static function fromUnsafeNode(DOMNode $node, callable ... $configurators): self
     {
         return self::fromDocument(
             Document::fromUnsafeDocument(
@@ -51,12 +50,12 @@ final class Xpath
 
     /**
      * @template T
-     * @param \Closure(DOMXpath): T $locator
+     * @param callable(DOMXpath): T $locator
      *
      * @return T
      * @throws RuntimeException
      */
-    public function locate(Closure $locator)
+    public function locate(callable $locator)
     {
         return $locator($this->xpath);
     }

--- a/src/Xml/ErrorHandling/Issue/IssueCollection.php
+++ b/src/Xml/ErrorHandling/Issue/IssueCollection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\ErrorHandling\Issue;
 
-use Closure;
 use Countable;
 use IteratorAggregate;
 use Psl\Dict;
@@ -46,11 +45,11 @@ final class IssueCollection implements Countable, IteratorAggregate
     }
 
     /**
-     * @param (\Closure(Issue): bool) $filter
+     * @param (callable(Issue): bool) $filter
      */
-    public function filter(Closure $filter): self
+    public function filter(callable $filter): self
     {
-        return new self(...Dict\filter($this->issues, $filter));
+        return new self(...Dict\filter($this->issues, $filter(...)));
     }
 
     public function getHighestLevel(): ?Level

--- a/src/Xml/Reader/Node/ElementNode.php
+++ b/src/Xml/Reader/Node/ElementNode.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Reader\Node;
 
-use Closure;
 use XMLReader;
 
 /**
@@ -26,9 +25,9 @@ final class ElementNode
     }
 
     /**
-     * @param \Closure(): list<AttributeNode>  $attributesProvider
+     * @param callable(): list<AttributeNode>  $attributesProvider
      */
-    public static function fromReader(XMLReader $reader, int $position, Closure $attributesProvider): self
+    public static function fromReader(XMLReader $reader, int $position, callable $attributesProvider): self
     {
         return new self(
             $position,

--- a/src/Xml/Reader/Reader.php
+++ b/src/Xml/Reader/Reader.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Reader;
 
-use Closure;
 use Generator;
 use VeeWee\Xml\Exception\RuntimeException;
 use VeeWee\Xml\Reader\Node\AttributeNode;
@@ -20,52 +19,52 @@ use function VeeWee\Xml\Util\configure;
 final class Reader
 {
     /**
-     * @var \Closure(): XMLReader $factory
+     * @var callable(): XMLReader $factory
      */
     private $factory;
 
     /**
-     * @param \Closure(): XMLReader $factory
+     * @param callable(): XMLReader $factory
      */
     private function __construct(
-        Closure $factory
+        callable $factory
     ) {
         $this->factory = $factory;
     }
 
     /**
-     * @param \Closure(): XMLReader $loader
-     * @param list<\Closure(XMLReader): XMLReader> $configurators
+     * @param callable(): XMLReader $loader
+     * @param list<callable(XMLReader): XMLReader> $configurators
      */
-    public static function configure(Closure $loader, Closure ... $configurators): self
+    public static function configure(callable $loader, callable ... $configurators): self
     {
         return new self(static fn () => configure(...$configurators)($loader()));
     }
 
     /**
-     * @param list<\Closure(XMLReader): XMLReader> $configurators
+     * @param list<callable(XMLReader): XMLReader> $configurators
      */
-    public static function fromXmlFile(string $file, Closure ... $configurators): self
+    public static function fromXmlFile(string $file, callable ... $configurators): self
     {
         return self::configure(xml_file_loader($file), ...$configurators);
     }
 
     /**
-     * @param list<\Closure(XMLReader): XMLReader> $configurators
+     * @param list<callable(XMLReader): XMLReader> $configurators
      */
-    public static function fromXmlString(string $xml, Closure ... $configurators): self
+    public static function fromXmlString(string $xml, callable ... $configurators): self
     {
         return self::configure(xml_string_loader($xml), ...$configurators);
     }
 
     /**
-     * @param \Closure(NodeSequence): bool $matcher
+     * @param callable(NodeSequence): bool $matcher
      *
      * @return Generator<string>
      *
      * @throws RuntimeException
      */
-    public function provide(Closure $matcher): Generator
+    public function provide(callable $matcher): Generator
     {
         $reader = ($this->factory)();
         $pointer = Pointer::create();

--- a/src/Xml/Util/configure.php
+++ b/src/Xml/Util/configure.php
@@ -16,23 +16,23 @@ use Psl\Iter;
  *
  * @template T
  *
- * @param Closure(T): T ...$stages
+ * @param callable(T): T ...$stages
  *
  * @return Closure(T): T
  *
  * @pure
  */
-function configure(Closure ...$stages): Closure
+function configure(callable ...$stages): Closure
 {
     return static fn ($input) => Iter\reduce(
         $stages,
         /**
          * @param T $input
-         * @param (Closure(T): T) $next
+         * @param (callable(T): T) $next
          *
          * @return T
          */
-        static fn (mixed $input, Closure $next): mixed => $next($input),
+        static fn (mixed $input, callable $next): mixed => $next($input),
         $input
     );
 }

--- a/src/Xml/Writer/Writer.php
+++ b/src/Xml/Writer/Writer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Writer;
 
-use Closure;
 use Generator;
 use VeeWee\Xml\Exception\RuntimeException;
 use XMLWriter;
@@ -24,26 +23,26 @@ final class Writer
     }
 
     /**
-     * @param list<(\Closure(XMLWriter): XMLWriter)> $configurators
+     * @param list<(callable(XMLWriter): XMLWriter)> $configurators
      */
-    public static function configure(Closure ... $configurators): self
+    public static function configure(callable ... $configurators): self
     {
         return self::fromUnsafeWriter(new XMLWriter(), ...$configurators);
     }
 
     /**
-     * @param list<(\Closure(XMLWriter): XMLWriter)> $configurators
+     * @param list<(callable(XMLWriter): XMLWriter)> $configurators
      */
-    public static function fromUnsafeWriter(XMLWriter $writer, Closure ... $configurators): self
+    public static function fromUnsafeWriter(XMLWriter $writer, callable ... $configurators): self
     {
         return new self(configure(...$configurators)($writer));
     }
 
     /**
-     * @param list<(\Closure(XMLWriter): XMLWriter)> $configurators
+     * @param list<(callable(XMLWriter): XMLWriter)> $configurators
      *
      */
-    public static function forFile(string $file, Closure ... $configurators): self
+    public static function forFile(string $file, callable ... $configurators): self
     {
         return self::configure(
             open(xml_file_opener($file)),
@@ -52,10 +51,10 @@ final class Writer
     }
 
     /**
-     * @param \Closure(XMLWriter): Generator<bool> $writer
+     * @param callable(XMLWriter): Generator<bool> $writer
      * @throws RuntimeException
      */
-    public function write(Closure $writer): void
+    public function write(callable $writer): void
     {
         $xmlWriter = $this->writer;
         $cursor = $writer($xmlWriter);

--- a/src/Xml/Xsd/Schema/SchemaCollection.php
+++ b/src/Xml/Xsd/Schema/SchemaCollection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Xsd\Schema;
 
-use Closure;
 use Countable;
 use IteratorAggregate;
 use Traversable;
@@ -47,32 +46,32 @@ final class SchemaCollection implements Countable, IteratorAggregate
     }
 
     /**
-     * @param \Closure(SchemaCollection): SchemaCollection $manipulator
+     * @param callable(SchemaCollection): SchemaCollection $manipulator
      */
-    public function manipulate(Closure $manipulator): self
+    public function manipulate(callable $manipulator): self
     {
         /** @psalm-suppress ImpureFunctionCall */
         return $manipulator($this);
     }
 
     /**
-     * @param \Closure(Schema): bool $filter
+     * @param callable(Schema): bool $filter
      */
-    public function filter(Closure $filter): self
+    public function filter(callable $filter): self
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return new self(...filter($this->schemas, $filter));
+        return new self(...filter($this->schemas, $filter(...)));
     }
 
     /**
      * @template T
-     * @param \Closure(Schema): T $mapper
+     * @param callable(Schema): T $mapper
      *
      * @return list<T>
      */
-    public function map(Closure $mapper)
+    public function map(callable $mapper)
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return map($this->schemas, $mapper);
+        return map($this->schemas, $mapper(...));
     }
 }

--- a/src/Xml/Xslt/Processor.php
+++ b/src/Xml/Xslt/Processor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Xslt;
 
-use Closure;
 use VeeWee\Xml\Dom\Document;
 use XSLTProcessor;
 use function VeeWee\Xml\Dom\Mapper\from_template_document;
@@ -22,9 +21,9 @@ final class Processor
     }
 
     /**
-     * @param list<\Closure(XSLTProcessor): XSLTProcessor> $configurators
+     * @param list<callable(XSLTProcessor): XSLTProcessor> $configurators
      */
-    public static function configure(Closure ... $configurators): self
+    public static function configure(callable ... $configurators): self
     {
         return new self(
             configure(...$configurators)(new XSLTProcessor())
@@ -32,9 +31,9 @@ final class Processor
     }
 
     /**
-     * @param list<\Closure(XSLTProcessor): XSLTProcessor> $configurators
+     * @param list<callable(XSLTProcessor): XSLTProcessor> $configurators
      */
-    public static function fromTemplateDocument(Document $template, Closure ... $configurators): self
+    public static function fromTemplateDocument(Document $template, callable ... $configurators): self
     {
         return self::configure(
             loader(from_template_document($template)),
@@ -44,10 +43,10 @@ final class Processor
 
     /**
      * @template T
-     * @param \Closure(XSLTProcessor): T $transformer
+     * @param callable(XSLTProcessor): T $transformer
      * @return T
      */
-    public function transform(Closure $transformer): mixed
+    public function transform(callable $transformer): mixed
     {
         return $transformer($this->processor);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

PSL2 requires all functions to have closures.
So I decided that was a good approach for this package as well, to keep things straight forward.

Whilst upgrading other packages, I noticed this is really a pain in the *ss. Especially since a lot of the implementations are __invokable classes that contain a lot of logic. Of course it is possible to wrap them with a (...) first class callable syntax. But this feels like a bit too much syntactical overhead, resulting in worsened developer experience.


As a middle-way, the main entry classes will allow callables. Just like they did before.
Since other functions most of the time return closures. I think it is okay to keep Closures in there.
Just to make them talk easier with PSL.

Time will tell if this is a good idea :)