### PR TITLE
Add 'expect*' shortcut functions to NodeList

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,4 +31,4 @@ jobs:
             - name: Run the tests
               run: composer run tests
             - name: Check tests quality
-              run: composer run testquality || (cat infection.log && exit 1)
+              run: composer run testquality

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "coverage": "@php ./tools/full-coverage-check.php .phpunit.cache/clover/clover.xml",
         "infection": [
             "Composer\\Config::disableProcessTimeout",
-            "./tools/infection.phar"
+            "./tools/infection.phar --show-mutations -v"
         ],
         "ci": [
             "@autoload",

--- a/src/Xml/Dom/Collection/NodeList.php
+++ b/src/Xml/Dom/Collection/NodeList.php
@@ -18,6 +18,7 @@ use VeeWee\Xml\Dom\Xpath;
 use VeeWee\Xml\Exception\RuntimeException;
 use Webmozart\Assert\Assert;
 use function Psl\Iter\reduce;
+use function Psl\Str\format;
 use function Psl\Vec\filter;
 use function Psl\Vec\flat_map;
 use function Psl\Vec\map;
@@ -95,6 +96,17 @@ final class NodeList implements Countable, IteratorAggregate
     public function item(int $index)
     {
         return $this->nodes[$index] ?? null;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @return T
+     */
+    public function expectItem(int $index, string $message = '')
+    {
+        Assert::notNull($item = $this->item($index), format($message ?: 'No item found at index %s', $index));
+
+        return $item;
     }
 
     public function count(): int
@@ -211,11 +223,43 @@ final class NodeList implements Countable, IteratorAggregate
     }
 
     /**
+     * @throws InvalidArgumentException
+     * @return T
+     */
+    public function expectFirst(string $message = '')
+    {
+        return $this->expectItem(0, $message);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @return T
+     */
+    public function expectSingle(string $message = '')
+    {
+        Assert::true(
+            $this->count() === 1,
+            format($message ?: 'Expected to find exactly one node. Got %s', count($this))
+        );
+
+        return $this->expectItem(0);
+    }
+
+    /**
      * @return T|null
      */
     public function last()
     {
         return $this->item($this->count() - 1);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @return T
+     */
+    public function expectLast(string $message = '')
+    {
+        return $this->expectItem($this->count() - 1, $message);
     }
 
     /**

--- a/tests/Xml/Dom/Collection/NodeListTest.php
+++ b/tests/Xml/Dom/Collection/NodeListTest.php
@@ -103,7 +103,20 @@ final class NodeListTest extends TestCase
         static::assertSame(null, $items->item(4));
     }
 
-    
+    public function test_it_can_expect_items()
+    {
+        $items = $this->loadProducts();
+
+        static::assertSame('0', $items->expectItem(0)->getAttribute('id'));
+        static::assertSame('1', $items->expectItem(1)->getAttribute('id'));
+        static::assertSame('2', $items->expectItem(2)->getAttribute('id'));
+        static::assertSame('3', $items->expectItem(3)->getAttribute('id'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No item found at index 4');
+        static::assertSame(null, $items->expectItem(4, 'No item found at index %s'));
+    }
+
     public function test_it_can_map(): void
     {
         $items = $this->loadProducts()->map(
@@ -213,6 +226,44 @@ final class NodeListTest extends TestCase
         static::assertSame(null, NodeList::empty()->first());
     }
 
+    public function test_it_can_expect_first(): void
+    {
+        $prices = $this->loadPrices();
+
+        static::assertSame($prices->item(0), $prices->expectFirst());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No first item was found');
+        NodeList::empty()->expectFirst('No first item was found');
+    }
+
+    public function test_it_can_expect_single(): void
+    {
+        $prices = $this->loadPrices();
+        $singlePrices = $prices->eq(0);
+
+        static::assertSame($prices->item(0), $singlePrices->expectSingle());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected single element, got 4 elements.');
+        $prices->expectSingle('Expected single element, got %s elements.');
+    }
+
+    public function test_it_can_expect_single_on_empty_list(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected single element, got 0 elements.');
+        NodeList::empty()->expectSingle('Expected single element, got %s elements.');
+    }
+
+    public function test_it_can_expect_single_on_a_two_item_list(): void
+    {
+        $prices = $this->loadPrices();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected single element, got 2 elements.');
+        $prices->filter(static fn (DOMElement $price): bool => (int)$price->textContent >= 2)->expectSingle('Expected single element, got %s elements.');
+    }
+
     public function test_it_can_get_last(): void
     {
         $prices = $this->loadPrices();
@@ -221,6 +272,16 @@ final class NodeListTest extends TestCase
         static::assertSame(null, NodeList::empty()->last());
     }
 
+    public function test_it_can_expect_last(): void
+    {
+        $prices = $this->loadPrices();
+
+        static::assertSame($prices->item(3), $prices->expectLast());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No last item was found');
+        NodeList::empty()->expectFirst('No last item was found');
+    }
     
     public function test_it_can_search_ancestors(): void
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Provides shortcut functions to the `NodeList` that allow you to grab a single element OR throw a customizable exception instead.

```php
$item = $list->expectAt(0, 'Expected an element at index %s');
$item = $list->expectFirst('Expected a first element.');
$item = $list->expectSingle('Expected exactly 1 element, got %s');
$item = $list->expectLast('Expected an element at index %s');
```
