### PR TITLE
Add document_uri DOM configurator

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -437,6 +437,22 @@ Document::fromXmlFile(
 ```
 
 
+#### document_uri
+
+Allows you to keep track of the document uri, even if you are using an in-memory string.
+Internally, it sets `DOMDocument::$documentURI`, which gets used as `file` in the [error-handling issues component](./error-handling.md#issues).
+
+```php
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Configurator\document_uri;
+
+$wsdl = 'http://myservice.com?wsdl';
+Document::fromXmlString(
+    $loadFromHttp($wsdl),
+    document_uri($wsdl)
+);
+```
+
 #### loader
 
 The loader configurator takes a [loader](#loaders) to specify the source of the DOM Document.

--- a/src/Xml/Dom/Configurator/document_uri.php
+++ b/src/Xml/Dom/Configurator/document_uri.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Dom\Configurator;
+
+use Closure;
+use DOMDocument;
+
+/**
+ * @param non-empty-string $documentUri
+ * @return \Closure(DOMDocument): DOMDocument
+ */
+function document_uri(string $documentUri): Closure
+{
+    return static function (DOMDocument $document) use ($documentUri) : DOMDocument {
+        $document->documentURI = $documentUri;
+
+        return $document;
+    };
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -18,6 +18,7 @@ require_once __DIR__.'/Xml/Dom/Builder/xmlns_attribute.php';
 require_once __DIR__.'/Xml/Dom/Builder/xmlns_attributes.php';
 require_once __DIR__.'/Xml/Dom/Configurator/canonicalize.php';
 require_once __DIR__.'/Xml/Dom/Configurator/comparable.php';
+require_once __DIR__.'/Xml/Dom/Configurator/document_uri.php';
 require_once __DIR__.'/Xml/Dom/Configurator/loader.php';
 require_once __DIR__.'/Xml/Dom/Configurator/normalize.php';
 require_once __DIR__.'/Xml/Dom/Configurator/optimize_namespaces.php';

--- a/tests/Xml/Dom/Configurator/DocumentUriTest.php
+++ b/tests/Xml/Dom/Configurator/DocumentUriTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Dom\Configurator;
+
+use DOMDocument;
+use PHPUnit\Framework\TestCase;
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Configurator\document_uri;
+use function VeeWee\Xml\Dom\Validator\xsd_validator;
+
+final class DocumentUriTest extends TestCase
+{
+    public function test_it_can_use_document_uri(): void
+    {
+        $doc = new DOMDocument();
+        $doc->loadXML($xml = '<hello />');
+
+        static::assertStringStartsWith(getcwd(), $doc->documentURI);
+        $configurator = document_uri($documentUri = 'myfile.wsdl');
+
+        $result = $configurator($doc);
+        static::assertSame($doc, $result);
+        static::assertSame($documentUri, $doc->documentURI);
+    }
+
+    public function test_it_uses_document_uri_in_error_reporting(): void
+    {
+        $xmlFile = $this->getFixture('xsd-namespace-invalid.xml');
+        $xsdFile = $this->getFixture('note-nonamespace.xsd');
+
+        $doc = Document::fromXmlFile(
+            $xmlFile,
+            document_uri($documentUri = 'myfile.wsdl'),
+        );
+        $validator = xsd_validator($xsdFile);
+
+        $issues = $doc->validate($validator);
+
+        static::assertCount(1, $issues);
+        static::assertSame($documentUri, ([...$issues][0])->file());
+    }
+
+    private function getFixture(string $fixture): string
+    {
+        $file = FIXTURE_DIR.'/dom/validator/xsd/'.$fixture;
+        static::assertFileExists($file);
+
+        return $file;
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues |

#### Summary
Allows you to keep track of the document uri, even if you are using an in-memory string.
Internally, it sets `DOMDocument::$documentURI`, which gets used as `file` in the [error handling issues component](https://github.com/veewee/xml/blob/main/docs/error-handling.md#issues).

```php
use VeeWee\Xml\Dom\Document;
use function VeeWee\Xml\Dom\Configurator\document_uri;

$wsdl = 'http://myservice.com?wsdl';
Document::fromXmlString(
    $loadFromHttp($wsdl),
    document_uri($wsdl)
);
```
