### PR TITLE
Fix mutable nodeList reference during traversal

### DIFF
--- a/src/Xml/Dom/Traverser/Traverser.php
+++ b/src/Xml/Dom/Traverser/Traverser.php
@@ -6,6 +6,7 @@ namespace VeeWee\Xml\Dom\Traverser;
 
 use DOMNode;
 use function VeeWee\Xml\Dom\Locator\Attribute\attributes_list;
+use function VeeWee\Xml\Dom\Locator\Node\children;
 
 final class Traverser
 {
@@ -30,7 +31,7 @@ final class Traverser
             $this->traverse($attribute);
         }
 
-        foreach ($node->childNodes as $child) {
+        foreach (children($node) as $child) {
             $this->traverse($child);
         }
 

--- a/src/Xml/ErrorHandling/detect_issues.php
+++ b/src/Xml/ErrorHandling/detect_issues.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\ErrorHandling;
 
-use LibXMLError;
 use Psl\Result;
 use Psl\Result\ResultInterface;
 
@@ -31,7 +30,6 @@ function detect_issues(callable $run): array
 
     $result = Result\wrap($run(...));
 
-    /** @var list<LibXMLError> $errors */
     $errors = libxml_get_errors();
     libxml_clear_errors();
     libxml_use_internal_errors($previousErrorReporting);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #49

#### Summary

Closes #49

childNodes is a mutable nodeList of which the count gets altered when one of its nodes gets removed whilst iterating.
This breaks the foreach:

https://3v4l.org/FksZo


```php
<?php

$doc = new DOMDocument();
$doc->preserveWhiteSpace = false;
$doc->loadXML(
    <<<EOXML
    <x>
        <item1 />
        <item2 />
        <item3 />
        <item4 />
    </x>
EOXML
);

foreach ($doc->documentElement->childNodes as $i => $node) {
    echo $node->localName . PHP_EOL;
    if ($i === 2) {
        $node->remove();
    }
}
````

Output:

> item1
> item2
> item3


This change uses the built-in immutable `NodeList` instead inside the traverser.
Making it possible to make visitors like this:


```php
class RemoveEmptyElementsVisitor extends AbstractVisitor {
    public function onNodeLeave(\DOMNode $node): Action
    {
        if (!is_element($node)) {
            return new Action\Noop();
        }

        if (trim($node->textContent) !== '') {
            return new Action\Noop();
        }

        return new Action\RemoveNode();
    }
}

```
