### PR TITLE
Cdata functions

### DIFF
--- a/docs/dom.md
+++ b/docs/dom.md
@@ -75,6 +75,21 @@ try {
 }
 ```
 
+#### assert_cdata
+
+Assert if a node is of type `DOMCdataSection`.
+
+```php
+use Psl\Type\Exception\AssertException;
+use function VeeWee\Xml\Dom\Assert\assert_cdata;
+
+try {
+    assert_cdata($someNode)
+} catch (AssertException $e) {
+    // Deal with it
+}
+```
+
 #### assert_document
 
 Assert if a node is of type `DOMDocument`.
@@ -203,6 +218,26 @@ element('foo',
 
 ```xml
 <foo hello="world" bar="baz" />
+```
+
+#### cdata
+
+Operates on a `DOMNode` and creates a `DOMCdataSection`.
+It can contain a set of configurators that can be used to dynamically change the cdata's contents.
+
+```php
+use function VeeWee\Xml\Dom\Builder\attribute;
+use function VeeWee\Xml\Dom\Builder\element;
+use function VeeWee\Xml\Dom\Builder\cdata;
+use function VeeWee\Xml\Dom\Builder\children;
+
+element('hello', children(
+    cdata('<html>world</html>')
+));
+```
+
+```xml
+<hello><![CDATA[<html>world</html>]]></hello>
 ```
 
 #### children
@@ -1153,6 +1188,18 @@ Checks if a node is of type `DOMAttr`.
 use function VeeWee\Xml\Dom\Predicate\is_attribute;
 
 if (is_attribute($someNode)) {
+   // ...
+}
+```
+
+#### is_cdata
+
+Checks if a node is of type `DOMCdataSection`.
+
+```php
+use function VeeWee\Xml\Dom\Predicate\is_cdata;
+
+if (is_cdata($someNode)) {
    // ...
 }
 ```

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -232,7 +232,7 @@ More information about [the PHP format can be found here](#php-format).
                     'id' => 2,
                     'test:type' => 'hello'  
                 ],
-                '@value' => 'Moon'
+                '@cdata' => '<html>Moon</html>'
             ]
         ]
     ]
@@ -253,6 +253,10 @@ More information about [the PHP format can be found here](#php-format).
     - You can provide any value that can be coerced to a string as an element value.
     - If the element does not have attributes, you can directly pass the value to the element name. In that case there is no need for the `@value` section.
     - All XML entities `<>"'` will be encoded before inserting a value into XML.
+- The `@cdata` section can be used for escaping HTML/XML content inside your XML element.
+  - You can provide any value that can be coerced to a string as an element value.
+  - The content will be wrapped with `<[CDATA[ ]]>`, special XML entities will not be escaped
+  - During decoding, cdata information will get lost: the element's `@value` will contain escaped XML entities. This is because an element can contain a mix of cdata and text nodes.
 - You can nest a single element or an array of elements into a parent element.
 
 #### Decoded types

--- a/src/Xml/Dom/Assert/assert_cdata.php
+++ b/src/Xml/Dom/Assert/assert_cdata.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Dom\Assert;
+
+use DOMCdataSection;
+use Psl\Type\Exception\AssertException;
+use function Psl\Type\instance_of;
+
+/**
+ * @psalm-assert DOMCdataSection $node
+ * @throws AssertException
+ */
+function assert_cdata(mixed $node): DOMCdataSection
+{
+    return instance_of(DOMCdataSection::class)->assert($node);
+}

--- a/src/Xml/Dom/Builder/cdata.php
+++ b/src/Xml/Dom/Builder/cdata.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Dom\Builder;
+
+use Closure;
+use DOMCdataSection;
+use DOMDocument;
+use DOMNode;
+use Webmozart\Assert\Assert;
+use function VeeWee\Xml\Dom\Assert\assert_cdata;
+use function VeeWee\Xml\Dom\Predicate\is_document;
+use function VeeWee\Xml\Internal\configure;
+
+/**
+ * @param list<callable(DOMCdataSection): DOMCdataSection> $configurators
+ *
+ * @return \Closure(DOMNode): DOMCdataSection
+ */
+function cdata(string $data, ...$configurators): Closure
+{
+    return static function (DOMNode $node) use ($data, $configurators): DOMCdataSection {
+        $document = is_document($node) ? $node : $node->ownerDocument;
+        Assert::isInstanceOf($document, DOMDocument::class, 'Can not create cdata without a DOM document.');
+
+        return assert_cdata(
+            configure(...$configurators)($document->createCDATASection($data))
+        );
+    };
+}

--- a/src/Xml/Dom/Predicate/is_cdata.php
+++ b/src/Xml/Dom/Predicate/is_cdata.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Dom\Predicate;
+
+use DOMCdataSection;
+use DOMNode;
+
+/**
+ * @psalm-assert-if-true DOMCdataSection $node
+ */
+function is_cdata(DOMNode $node): bool
+{
+    return $node instanceof DOMCdataSection;
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
 require_once __DIR__.'/Xml/Dom/Assert/assert_attribute.php';
+require_once __DIR__.'/Xml/Dom/Assert/assert_cdata.php';
 require_once __DIR__.'/Xml/Dom/Assert/assert_document.php';
 require_once __DIR__.'/Xml/Dom/Assert/assert_dom_node_list.php';
 require_once __DIR__.'/Xml/Dom/Assert/assert_element.php';
 require_once __DIR__.'/Xml/Dom/Builder/attribute.php';
 require_once __DIR__.'/Xml/Dom/Builder/attributes.php';
+require_once __DIR__.'/Xml/Dom/Builder/cdata.php';
 require_once __DIR__.'/Xml/Dom/Builder/children.php';
 require_once __DIR__.'/Xml/Dom/Builder/element.php';
 require_once __DIR__.'/Xml/Dom/Builder/escaped_value.php';
@@ -67,6 +69,7 @@ require_once __DIR__.'/Xml/Dom/Manipulator/append.php';
 require_once __DIR__.'/Xml/Dom/Mapper/xml_string.php';
 require_once __DIR__.'/Xml/Dom/Mapper/xslt_template.php';
 require_once __DIR__.'/Xml/Dom/Predicate/is_attribute.php';
+require_once __DIR__.'/Xml/Dom/Predicate/is_cdata.php';
 require_once __DIR__.'/Xml/Dom/Predicate/is_default_xmlns_attribute.php';
 require_once __DIR__.'/Xml/Dom/Predicate/is_document.php';
 require_once __DIR__.'/Xml/Dom/Predicate/is_document_element.php';

--- a/tests/Xml/Dom/Assert/AssertCDataTest.php
+++ b/tests/Xml/Dom/Assert/AssertCDataTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Dom\Assert;
+
+use DOMNode;
+use PHPUnit\Framework\TestCase;
+use Psl\Type\Exception\AssertException;
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Assert\assert_cdata;
+
+final class AssertCDataTest extends TestCase
+{
+    /**
+     *
+     * @dataProvider provideTestCases
+     */
+    public function test_it_knows_cdata(?DOMNode $node, bool $expected): void
+    {
+        if (!$expected) {
+            $this->expectException(AssertException::class);
+        }
+
+        $actual = assert_cdata($node);
+        static::assertSame($node, $actual);
+    }
+
+    public function provideTestCases()
+    {
+        $doc = Document::fromXmlString(
+            <<<EOXML
+            <doc><![CDATA[<html>HELLO</html]]></doc>
+            EOXML
+        )->toUnsafeDocument();
+
+        yield [$doc, false];
+        yield [$doc->documentElement, false];
+        yield [$doc->documentElement->firstChild, true];
+        yield [null, false];
+    }
+}

--- a/tests/Xml/Dom/Builder/CdataTest.php
+++ b/tests/Xml/Dom/Builder/CdataTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Dom\Builder;
+
+use DOMCdataSection;
+use DOMDocument;
+use PHPUnit\Framework\TestCase;
+use function Psl\Fun\identity;
+use function VeeWee\Xml\Dom\Builder\cdata;
+use function VeeWee\Xml\Dom\Mapper\xml_string;
+
+final class CdataTest extends TestCase
+{
+    public function test_it_can_build_cdata(): void
+    {
+        $doc = new DOMDocument();
+        $node = cdata($data = '<html>hello</html>')($doc);
+
+        static::assertInstanceOf(DOMCdataSection::class, $node);
+        static::assertSame($data, $node->textContent);
+        static::assertSame(xml_string()($node), '<![CDATA['.$data.']]>');
+    }
+
+    public function test_it_can_build_cdata_with_configurators(): void
+    {
+        $doc = new DOMDocument();
+        $node = cdata($data = '<html>hello</html>', identity())($doc);
+
+        static::assertInstanceOf(DOMCdataSection::class, $node);
+        static::assertSame($data, $node->textContent);
+    }
+}

--- a/tests/Xml/Dom/Builder/ChildrenTest.php
+++ b/tests/Xml/Dom/Builder/ChildrenTest.php
@@ -6,8 +6,10 @@ namespace VeeWee\Tests\Xml\Dom\Builder;
 
 use DOMDocument;
 use PHPUnit\Framework\TestCase;
+use function VeeWee\Xml\Dom\Builder\cdata;
 use function VeeWee\Xml\Dom\Builder\children;
 use function VeeWee\Xml\Dom\Builder\element;
+use function VeeWee\Xml\Dom\Mapper\xml_string;
 
 final class ChildrenTest extends TestCase
 {
@@ -27,7 +29,6 @@ final class ChildrenTest extends TestCase
         static::assertSame('world2', $children->item(1)->nodeName);
     }
 
-    
     public function test_it_can_build_an_element_with_children(): void
     {
         $doc = new DOMDocument();
@@ -47,5 +48,21 @@ final class ChildrenTest extends TestCase
         static::assertSame(2, $children->count());
         static::assertSame('world1', $children->item(0)->nodeName);
         static::assertSame('world2', $children->item(1)->nodeName);
+    }
+
+    public function test_it_can_add_cdata(): void
+    {
+        $doc = new DOMDocument();
+        $node = element(
+            'hello',
+            children(
+                cdata('<html>world</html>'),
+            )
+        )($doc);
+
+        static::assertXmlStringEqualsXmlString(
+            '<hello><![CDATA[<html>world</html>]]></hello>',
+            xml_string()($node)
+        );
     }
 }

--- a/tests/Xml/Dom/Builder/NodesTest.php
+++ b/tests/Xml/Dom/Builder/NodesTest.php
@@ -20,7 +20,7 @@ final class NodesTest extends TestCase
             static fn (DOMDocument $doc): array => [
                 element('many1')($doc),
                 element('many2')($doc),
-            ]
+            ],
         )($doc);
 
         static::assertCount(4, $nodes);

--- a/tests/Xml/Dom/Manipulator/Node/RenameTest.php
+++ b/tests/Xml/Dom/Manipulator/Node/RenameTest.php
@@ -13,6 +13,7 @@ use function VeeWee\Xml\Dom\Configurator\comparable;
 use function VeeWee\Xml\Dom\Locator\document_element;
 use function VeeWee\Xml\Dom\Manipulator\Node\remove_namespace;
 use function VeeWee\Xml\Dom\Manipulator\Node\rename;
+use function VeeWee\Xml\Dom\Mapper\xml_string;
 use function VeeWee\Xml\Dom\Xpath\Configurator\namespaces;
 
 final class RenameTest extends TestCase

--- a/tests/Xml/Dom/Manipulator/Node/RenameTest.php
+++ b/tests/Xml/Dom/Manipulator/Node/RenameTest.php
@@ -13,7 +13,6 @@ use function VeeWee\Xml\Dom\Configurator\comparable;
 use function VeeWee\Xml\Dom\Locator\document_element;
 use function VeeWee\Xml\Dom\Manipulator\Node\remove_namespace;
 use function VeeWee\Xml\Dom\Manipulator\Node\rename;
-use function VeeWee\Xml\Dom\Mapper\xml_string;
 use function VeeWee\Xml\Dom\Xpath\Configurator\namespaces;
 
 final class RenameTest extends TestCase

--- a/tests/Xml/Dom/Predicate/IsCDataTest.php
+++ b/tests/Xml/Dom/Predicate/IsCDataTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Dom\Predicate;
+
+use DOMNode;
+use PHPUnit\Framework\TestCase;
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Predicate\is_cdata;
+
+final class IsCDataTest extends TestCase
+{
+    /**
+     *
+     * @dataProvider provideTestCases
+     */
+    public function test_it_knows_cdata(?DOMNode $node, bool $expected): void
+    {
+        $actual = is_cdata($node);
+        static::assertSame($expected, $actual);
+    }
+
+    public function provideTestCases()
+    {
+        $doc = Document::fromXmlString(
+            <<<EOXML
+            <doc><![CDATA[<html>HELLO</html]]></doc>
+            EOXML
+        )->toUnsafeDocument();
+
+        yield [$doc, false];
+        yield [$doc->documentElement, false];
+        yield [$doc->documentElement->firstChild, true];
+    }
+}

--- a/tests/Xml/Encoding/EncodingTest.php
+++ b/tests/Xml/Encoding/EncodingTest.php
@@ -239,6 +239,16 @@ final class EncodingTest extends TestCase
                 ]
             ]
         ];
+        yield 'cdata' => [
+            'xml' => '<hello><![CDATA[<html>world</html>]]></hello>',
+            'data' => ['hello' => [
+                '@cdata' => '<html>world</html>'
+            ]]
+        ];
+        yield 'mixed cdata' => [
+            'xml' => '<hello>hello <![CDATA[<html>world</html>]]></hello>',
+            'data' => ['hello' => 'hello <html>world</html>']
+        ];
     }
 
     public function provideRiskyBidirectionalCases()


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

#### assert_cdata

Assert if a node is of type `DOMCdataSection`.

```php
use Psl\Type\Exception\AssertException;
use function VeeWee\Xml\Dom\Assert\assert_cdata;

try {
    assert_cdata($someNode)
} catch (AssertException $e) {
    // Deal with it
}
```

#### cdata builder

Operates on a `DOMNode` and creates a `DOMCdataSection`.
It can contain a set of configurators that can be used to dynamically change the cdata's contents.

```php
use function VeeWee\Xml\Dom\Builder\attribute;
use function VeeWee\Xml\Dom\Builder\element;
use function VeeWee\Xml\Dom\Builder\cdata;
use function VeeWee\Xml\Dom\Builder\children;

element('hello', children(
    cdata('<html>world</html>')
));
```

```xml
<hello><![CDATA[<html>world</html>]]></hello>
```

#### is_cdata

Checks if a node is of type `DOMCdataSection`.

```php
use function VeeWee\Xml\Dom\Predicate\is_cdata;

if (is_cdata($someNode)) {
   // ...
}
```

#### encoding will now accept `@cdata`

```php
xml_encode(
            [
                '@attributes' => [
                    'id' => 2,
                    'test:type' => 'hello'  
                ],
                '@cdata' => '<html>Moon</html>'
            ]
);
```
(decoding will not result in `@cdata` but in `@value` with escaped XML entitites - because node children could be a mix of both text and cdata)