### PR TITLE
Introduce the nested() XML Reader matcher

### DIFF
--- a/src/Xml/Reader/Matcher/nested.php
+++ b/src/Xml/Reader/Matcher/nested.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Reader\Matcher;
+
+use Closure;
+use VeeWee\Xml\Reader\Node\NodeSequence;
+use function array_shift;
+
+/**
+ * A nested matcher can be used to match parts of an XML path in order to detect node you are interested in.
+ * Every match will create some kind of breakpoint of which the next matcher will start.
+ * This makes it possible to combine it with sequences.
+ * Between every matcher, there might be multiple nodes in between.
+ *
+ * ```php
+ * nested(
+ *     document_element(),
+ *     sequence(element_name('users'), element_name('user')),
+ *     element_name('email')
+ * );
+ * ```
+ *
+ * @param non-empty-list<callable(NodeSequence): bool> $matchers
+ *
+ * @return \Closure(NodeSequence): bool
+ */
+function nested(callable ... $matchers): Closure
+{
+    return static function (NodeSequence $sequence) use ($matchers) : bool {
+        $lastMatchedAtIndex = -1;
+        $currentMatcher = array_shift($matchers);
+        if (!$currentMatcher) {
+            return false;
+        }
+
+        $stepCount = $sequence->count();
+        foreach ($sequence->replay() as $index => $step) {
+            // Slice the step NodeSequence based on previous "match" breakpoint
+            // and see if it matches on current matcher:
+            $step = $step->slice($lastMatchedAtIndex + 1);
+            if (!$currentMatcher($step)) {
+                continue;
+            }
+
+            // If there was a match, select the next matcher and store the last matched NodeSequence index.
+            $currentMatcher = array_shift($matchers);
+            $lastMatchedAtIndex = $index;
+
+            // If the list of matchers is empty
+            // The function will return true if the element is the last step in the complete sequence.
+            // Otherwise, the nested match has an even deeper element on which we don't wish to match.
+            if (!$currentMatcher) {
+                $isLastStep = $index === $stepCount - 1;
+
+                return $isLastStep;
+            }
+        }
+
+        return false;
+    };
+}

--- a/src/Xml/Reader/Matcher/not.php
+++ b/src/Xml/Reader/Matcher/not.php
@@ -8,7 +8,7 @@ use Closure;
 use VeeWee\Xml\Reader\Node\NodeSequence;
 
 /**
- * @param callable(NodeSequence) $matcher
+ * @param callable(NodeSequence): bool $matcher
  *
  * @return \Closure(NodeSequence): bool
  */

--- a/src/Xml/Reader/Matcher/sequence.php
+++ b/src/Xml/Reader/Matcher/sequence.php
@@ -22,15 +22,12 @@ use function count;
 function sequence(callable ... $matcherSequence): Closure
 {
     return static function (NodeSequence $sequence) use ($matcherSequence) : bool {
-        $nodeSequence = $sequence->sequence();
-        if (count($matcherSequence) !== count($nodeSequence)) {
+        if (count($matcherSequence) !== $sequence->count()) {
             return false;
         }
 
-        $currentSequence = new NodeSequence();
-        foreach ($nodeSequence as $i => $node) {
-            $currentSequence = $currentSequence->append($node);
-            $matcher = $matcherSequence[$i];
+        foreach ($sequence->replay() as $index => $currentSequence) {
+            $matcher = $matcherSequence[$index];
             if (!$matcher($currentSequence)) {
                 return false;
             }

--- a/src/Xml/Reader/Node/NodeSequence.php
+++ b/src/Xml/Reader/Node/NodeSequence.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace VeeWee\Xml\Reader\Node;
 
+use Countable;
+use Generator;
 use InvalidArgumentException;
 use Webmozart\Assert\Assert;
+use function Psl\Vec\slice;
 
-final class NodeSequence
+final class NodeSequence implements Countable
 {
     /**
      * @var list<ElementNode>
@@ -62,6 +65,34 @@ final class NodeSequence
     public function sequence(): array
     {
         return $this->elementNodes;
+    }
+
+    public function count(): int
+    {
+        return \count($this->elementNodes);
+    }
+
+    /**
+     * @param non-negative-int $start
+     * @param non-negative-int|null $length
+     */
+    public function slice(int $start, ?int $length = null): self
+    {
+        return new self(...slice($this->elementNodes, $start, $length));
+    }
+
+    /**
+     * Replays every step in the sequence
+     *
+     * @return Generator<non-negative-int, NodeSequence, mixed, void>
+     */
+    public function replay(): Generator
+    {
+        $step = new self();
+        foreach ($this->elementNodes as $index => $node) {
+            $step = $step->append($node);
+            yield $index => $step;
+        }
     }
 
     /**

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -136,6 +136,7 @@ require_once __DIR__.'/Xml/Reader/Matcher/element_position.php';
 require_once __DIR__.'/Xml/Reader/Matcher/namespaced_attribute.php';
 require_once __DIR__.'/Xml/Reader/Matcher/namespaced_attribute_value.php';
 require_once __DIR__.'/Xml/Reader/Matcher/namespaced_element.php';
+require_once __DIR__.'/Xml/Reader/Matcher/nested.php';
 require_once __DIR__.'/Xml/Reader/Matcher/node_attribute.php';
 require_once __DIR__.'/Xml/Reader/Matcher/node_name.php';
 require_once __DIR__.'/Xml/Reader/Matcher/not.php';

--- a/tests/Xml/Reader/Matcher/NestedTest.php
+++ b/tests/Xml/Reader/Matcher/NestedTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Reader\Matcher;
+
+use Generator;
+use VeeWee\Xml\Reader\Node\ElementNode;
+use VeeWee\Xml\Reader\Node\NodeSequence;
+use function VeeWee\Xml\Reader\Matcher\all;
+use function VeeWee\Xml\Reader\Matcher\attribute_value;
+use function VeeWee\Xml\Reader\Matcher\document_element;
+use function VeeWee\Xml\Reader\Matcher\element_name;
+use function VeeWee\Xml\Reader\Matcher\nested;
+use function VeeWee\Xml\Reader\Matcher\sequence;
+
+final class NestedTest extends AbstractMatcherTest
+{
+    public static function provideRealXmlCases(): Generator
+    {
+        yield 'sequential' => [
+            nested(
+                document_element(),
+                element_name('users'),
+                all(
+                    element_name('user'),
+                    attribute_value('locale', 'nl')
+                )
+            ),
+            <<<'EOXML'
+            <root>
+                <users>
+                    <user locale="nl">Jos</user>
+                    <user>Bos</user>
+                    <user>Mos</user>
+                </users>
+            </root>
+            EOXML,
+            [
+                '<user locale="nl">Jos</user>',
+            ]
+        ];
+        yield 'skipped-items' => [
+            nested(
+                element_name('root'),
+                element_name('user'),
+            ),
+            <<<'EOXML'
+            <root>
+                <users>
+                    <user locale="nl">Jos</user>
+                    <user>Bos</user>
+                    <user>Mos</user>
+                </users>
+            </root>
+            EOXML,
+            [
+                '<user locale="nl">Jos</user>',
+                '<user>Bos</user>',
+                '<user>Mos</user>',
+            ]
+        ];
+        yield 'similar-paths' => [
+            nested(
+                element_name('users'),
+                element_name('user'),
+            ),
+            <<<'EOXML'
+            <root>
+                <users>
+                    <user>Jos</user>
+                    <user>Bos</user>
+                </users>
+                <admins>
+                    <user>Mos</user>
+                </admins>
+            </root>
+            EOXML,
+            [
+                '<user>Jos</user>',
+                '<user>Bos</user>',
+            ]
+        ];
+        yield 'combined-with-sequence' => [
+            nested(
+                document_element(),
+                sequence(
+                    element_name('users'),
+                    element_name('user'),
+                ),
+            ),
+            <<<'EOXML'
+            <root>
+                <users>
+                    <user>Jos</user>
+                    <user>Bos</user>
+                </users>
+            </root>
+            EOXML,
+            [
+                '<user>Jos</user>',
+                '<user>Bos</user>',
+            ]
+        ];
+        yield 'multi-parent-items' => [
+            nested(
+                element_name('root'),
+                element_name('user'),
+            ),
+            <<<'EOXML'
+            <root>
+                <users>
+                    <user>Jos</user>
+                    <user>Bos</user>
+                    
+                </users>
+                <admins>
+                    <user>Mos</user>
+                </admins>
+            </root>
+            EOXML,
+            [
+                '<user>Jos</user>',
+                '<user>Bos</user>',
+                '<user>Mos</user>',
+            ]
+        ];
+        yield 'in-between-match' => [
+            nested(
+                element_name('root'),
+                element_name('users'),
+            ),
+            <<<'EOXML'
+            <root>
+                <users>
+                    <user>Jos</user>
+                    <user>Bos</user>
+                </users>
+                <admins>
+                    <user>Mos</user>
+                </admins>
+            </root>
+            EOXML,
+            [
+                <<<'EOXML'
+                <users>
+                        <user>Jos</user>
+                        <user>Bos</user>
+                    </users>
+                EOXML,
+            ]
+        ];
+        yield 'deeply-nested-sequence' => [
+            nested(
+                document_element(),
+                sequence(element_name('users')),
+                sequence(element_name('user')),
+            ),
+            <<<'EOXML'
+            <root>
+                <users>
+                    <user>Jos</user>
+                    <user>Bos</user>
+                </users>
+            </root>
+            EOXML,
+            [
+                '<user>Jos</user>',
+                '<user>Bos</user>',
+            ]
+        ];
+    }
+
+    public static function provideMatcherCases(): Generator
+    {
+        yield 'it_returns_false_if_no_matcher' => [
+            nested(),
+            new NodeSequence(
+                new ElementNode(1, 'root', 'root', '', '', []),
+            ),
+            false
+        ];
+
+        yield 'it_returns_false_if_no_sequence' => [
+            nested(document_element()),
+            new NodeSequence(),
+            false
+        ];
+
+        yield 'it_returns_false_if_there_are_no_matchers_left_before_the_end_of_the_node_sequence' => [
+            nested(document_element()),
+            new NodeSequence(
+                new ElementNode(1, 'root', 'root', '', '', []),
+                new ElementNode(1, 'users', 'users', '', '', []),
+            ),
+            false
+        ];
+
+        yield 'it_returns_false_if_there_are_still_matchers_left_at_the_end_of_the_node_sequence' => [
+            nested(element_name('notfound')),
+            new NodeSequence(
+                new ElementNode(1, 'root', 'root', '', '', []),
+                new ElementNode(1, 'users', 'users', '', '', []),
+            ),
+            false
+        ];
+
+        yield 'it_returns_true_if_the_last_matcher_hits_the_end_of_the_node_sequence' => [
+            nested(element_name('root'), element_name('users')),
+            new NodeSequence(
+                new ElementNode(1, 'root', 'root', '', '', []),
+                new ElementNode(1, 'users', 'users', '', '', []),
+            ),
+            true
+        ];
+
+        yield 'it_can_skip_nodes_looking_for_the_next_one' => [
+            nested(element_name('root'), element_name('user')),
+            new NodeSequence(
+                new ElementNode(1, 'root', 'root', '', '', []),
+                new ElementNode(1, 'users', 'users', '', '', []),
+                new ElementNode(1, 'user', 'user', '', '', []),
+            ),
+            true
+        ];
+
+        yield 'it_uses_a_sliced_node_sequence_breakpoint_on_match' => [
+            nested(
+                element_name('root'),
+                sequence(
+                    element_name('users'),
+                    element_name('user')
+                )
+            ),
+            new NodeSequence(
+                new ElementNode(1, 'root', 'root', '', '', []),
+                new ElementNode(1, 'users', 'users', '', '', []),
+                new ElementNode(1, 'user', 'user', '', '', []),
+            ),
+            true
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 


#### Summary
Provide nested matchers that represents parts of an XML tree.
It can be used similar to the `//user` xpath operator to search on any matching node at any level in the XML 

Given:

```xml
<root>
    <users>
        <user locale="nl">Jos</user>
        <user>Bos</user>
        <user>Mos</user>    
    </users>
</root>
```

This matcher will grab the `user` element with `locale="nl"`

```php
use \VeeWee\Xml\Reader\Matcher;

Matcher\nested(
    // Breakpoint 1: <root />
    Matcher\document_element(),
    // Breakpoint 2: <user locale="nl">Jos</user>
    // Searches for all elements that matches `<user />` and attribute `locale="nl"` in the `<root />` document.
    // Note that you can skip matching on `<users />` here : it's not an exact matcher
    Matcher\all( 
        Matcher\element_name('user'),
        Matcher\attribute_value('locale', 'nl')
    )
);
```

Every provided matcher acts as a breakpoint in the `NodeSequence` for the next matcher,
making it composable with the exact XML tree [sequence](#sequence) matcher as well.

```php
use \VeeWee\Xml\Reader\Matcher;

Matcher\nested(
    // Breakpoint 1: <root />
    Matcher\document_element(),
    // Breakpoint 2: <user />
    // The nested matcher will provide the NodeSequence starting from the element after previous match.
    // The sequence will basically receive: 'users > user'
    Matcher\sequence( 
        // Level 0: The element inside <root /> at level 0 must exactly match <users /> 
        Matcher\element_name('users'),
        // Level 1: The element inside <root /> at level 1 must exactly match <user />
        Matcher\element_name('user'),
    ),
    // Breakpoint 3: <email />
    // After matching a sequence, you can still continue matching deeper or adding even more sequences:
    Matcher\element_name('email')
);
```