### PR TITLE
More stable node loading

### DIFF
--- a/src/Xml/Dom/Document.php
+++ b/src/Xml/Dom/Document.php
@@ -15,7 +15,6 @@ use VeeWee\Xml\Exception\RuntimeException;
 use function Psl\Vec\map;
 use function VeeWee\Xml\Dom\Configurator\loader;
 use function VeeWee\Xml\Dom\Loader\xml_file_loader;
-use function VeeWee\Xml\Dom\Loader\xml_node_loader;
 use function VeeWee\Xml\Dom\Loader\xml_string_loader;
 use function VeeWee\Xml\Dom\Locator\document_element;
 use function VeeWee\Xml\Dom\Mapper\xml_string;
@@ -80,7 +79,9 @@ final class Document
     public static function fromXmlNode(DOMNode $node, callable ...$configurators): self
     {
         return self::configure(
-            loader(xml_node_loader($node)),
+            loader(xml_string_loader(
+                xml_string()($node)
+            )),
             ...$configurators
         );
     }

--- a/tests/Xml/Dom/DocumentTest.php
+++ b/tests/Xml/Dom/DocumentTest.php
@@ -11,7 +11,9 @@ use VeeWee\Tests\Xml\Helper\FillFileTrait;
 use VeeWee\Xml\Dom\Document;
 use VeeWee\Xml\Dom\Traverser\Action;
 use VeeWee\Xml\Dom\Traverser\Visitor\AbstractVisitor;
+use VeeWee\Xml\Dom\Traverser\Visitor\RemoveNamespaces;
 use function Psl\Fun\identity;
+use function VeeWee\Xml\Dom\Configurator\traverse;
 use function VeeWee\Xml\Dom\Configurator\trim_spaces;
 use function VeeWee\Xml\Dom\Configurator\utf8;
 use function VeeWee\Xml\Dom\Locator\document_element;
@@ -65,7 +67,7 @@ final class DocumentTest extends TestCase
     }
 
 
-    public function test_it_can_create_a_document_from_xml_nod(): void
+    public function test_it_can_create_a_document_from_xml_node(): void
     {
         $source = new DOMDocument();
         $source->loadXML($xml = '<hello />');
@@ -78,6 +80,23 @@ final class DocumentTest extends TestCase
         static::assertXmlStringEqualsXmlString($xml, $doc->toXmlString());
     }
 
+    /**
+     * @see https://github.com/php/php-src/issues/12616
+     */
+    public function test_it_can_create_a_document_from_xml_node_with_removed_namespaces(): void
+    {
+        $source = Document::fromXmlString(
+            '<hello xmlns="https://hello" />',
+            traverse(RemoveNamespaces::all())
+        );
+
+        $doc = Document::fromXmlNode(
+            $source->map(document_element()),
+            identity()
+        );
+
+        static::assertXmlStringEqualsXmlString('<hello />', $doc->toXmlString());
+    }
 
     public function test_it_can_create_a_document_from_xml_file(): void
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

More info, see:

* https://github.com/saloonphp/xml-wrangler/pull/13
* https://github.com/php/php-src/issues/12616

This PR improves node imports by mapping the node to an XML string and reimporting that XML.

The old system that was using the `xml_node_loader` can result in faulty prefixes if XMLNS namespaces were removed in the source node. This is something that should be fixed in php-src. In the meantime, the improved node loader will resolve the issue as well.

Example:

```php
$doc = Document::fromXmlString(
    <<<XML
    <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
      <services>
        <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
        <service id="kernel" class="TicketSwap\Kernel" public="true" synthetic="true" autoconfigure="true">
          <tag xmlns="http://symfony.com/schema/dic/tag-1" name="controller.service_arguments">1</tag>
          <tag xmlns="http://symfony.com/schema/dic/tag-2"  name="routing.route_loader">2</tag>
        </service>
      </services>
    </container>
    XML,
    traverse(RemoveNamespaces::unprefixed())
);
echo $doc->toXmlString();

$xpath = $doc->xpath();
$res = $xpath->query('/container/services/service');
$node = $res->item(0);

// --> This is what happens internally in `element_decode()`
$doc = Document::fromXmlNode($node);
var_dump($doc->toXmlString());
```

Will result in the expected:

```xml
<?xml version="1.0"?>
<service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
```


Instead of the unexpexted and invalid:

```xml
<?xml version="1.0"?>
<default:service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
```