### PR TITLE
Revert "More stable node loading"

### DIFF
--- a/src/Xml/Dom/Document.php
+++ b/src/Xml/Dom/Document.php
@@ -15,6 +15,7 @@ use VeeWee\Xml\Exception\RuntimeException;
 use function Psl\Vec\map;
 use function VeeWee\Xml\Dom\Configurator\loader;
 use function VeeWee\Xml\Dom\Loader\xml_file_loader;
+use function VeeWee\Xml\Dom\Loader\xml_node_loader;
 use function VeeWee\Xml\Dom\Loader\xml_string_loader;
 use function VeeWee\Xml\Dom\Locator\document_element;
 use function VeeWee\Xml\Dom\Mapper\xml_string;
@@ -79,9 +80,7 @@ final class Document
     public static function fromXmlNode(DOMNode $node, callable ...$configurators): self
     {
         return self::configure(
-            loader(xml_string_loader(
-                xml_string()($node)
-            )),
+            loader(xml_node_loader($node)),
             ...$configurators
         );
     }

--- a/tests/Xml/Dom/DocumentTest.php
+++ b/tests/Xml/Dom/DocumentTest.php
@@ -11,9 +11,7 @@ use VeeWee\Tests\Xml\Helper\FillFileTrait;
 use VeeWee\Xml\Dom\Document;
 use VeeWee\Xml\Dom\Traverser\Action;
 use VeeWee\Xml\Dom\Traverser\Visitor\AbstractVisitor;
-use VeeWee\Xml\Dom\Traverser\Visitor\RemoveNamespaces;
 use function Psl\Fun\identity;
-use function VeeWee\Xml\Dom\Configurator\traverse;
 use function VeeWee\Xml\Dom\Configurator\trim_spaces;
 use function VeeWee\Xml\Dom\Configurator\utf8;
 use function VeeWee\Xml\Dom\Locator\document_element;
@@ -80,23 +78,6 @@ final class DocumentTest extends TestCase
         static::assertXmlStringEqualsXmlString($xml, $doc->toXmlString());
     }
 
-    /**
-     * @see https://github.com/php/php-src/issues/12616
-     */
-    public function test_it_can_create_a_document_from_xml_node_with_removed_namespaces(): void
-    {
-        $source = Document::fromXmlString(
-            '<hello xmlns="https://hello" />',
-            traverse(RemoveNamespaces::all())
-        );
-
-        $doc = Document::fromXmlNode(
-            $source->map(document_element()),
-            identity()
-        );
-
-        static::assertXmlStringEqualsXmlString('<hello />', $doc->toXmlString());
-    }
 
     public function test_it_can_create_a_document_from_xml_file(): void
     {


### PR DESCRIPTION
This reverts commit f059e2c2a2254063b3822938ee76b6e298a9922c.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

This commit reverts The more stable node loading from #61.
It turns out that this solution introduces some more problems.

It seems like a better idea to wait for a fix in PHP than to deal with these newer issues in this package.

More info, see: https://github.com/saloonphp/xml-wrangler/pull/16#issuecomment-1807114296