### PR TITLE
Add reader MatchingNode results and a signal to stop reading

### DIFF
--- a/src/Xml/Reader/MatchingNode.php
+++ b/src/Xml/Reader/MatchingNode.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Reader;
+
+use DOMDocument;
+use VeeWee\Xml\Dom\Document;
+use VeeWee\Xml\Encoding\Exception\EncodingException;
+use VeeWee\Xml\Exception\RuntimeException;
+use VeeWee\Xml\Reader\Node\NodeSequence;
+use function VeeWee\Xml\Encoding\xml_decode;
+
+final class MatchingNode
+{
+    /**
+     * @param non-empty-string $xml
+     */
+    public function __construct(
+        private readonly string $xml,
+        private readonly NodeSequence $nodeSequence
+    ) {
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function xml(): string
+    {
+        return $this->xml;
+    }
+
+    public function nodeSequence(): NodeSequence
+    {
+        return $this->nodeSequence;
+    }
+
+    /**
+     * @param list<callable(DOMDocument): DOMDocument> $configurators
+     *
+     * @throws RuntimeException
+     */
+    public function intoDocument(callable ... $configurators): Document
+    {
+        return Document::fromXmlString($this->xml, ...$configurators);
+    }
+
+    /**
+     * @param list<callable(DOMDocument): DOMDocument> $configurators
+     *
+     * @throws RuntimeException
+     * @throws EncodingException
+     */
+    public function decode(callable ... $configurators): array
+    {
+        return xml_decode($this->xml, ...$configurators);
+    }
+
+    /**
+     * @param callable(NodeSequence): bool $matcher
+     */
+    public function matches(callable $matcher): bool
+    {
+        return $matcher($this->nodeSequence);
+    }
+}

--- a/src/Xml/Reader/Signal.php
+++ b/src/Xml/Reader/Signal.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace VeeWee\Xml\Reader;
+
+final class Signal
+{
+    private bool $stopRequested = false;
+
+    public function stop(): void
+    {
+        $this->stopRequested = true;
+    }
+
+    public function stopRequested(): bool
+    {
+        return $this->stopRequested;
+    }
+}

--- a/tests/Xml/Reader/Configurator/SubstituteEntitiesTest.php
+++ b/tests/Xml/Reader/Configurator/SubstituteEntitiesTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace VeeWee\Tests\Xml\Reader\Configurator;
 
 use PHPUnit\Framework\TestCase;
+use VeeWee\Xml\Reader\MatchingNode;
 use VeeWee\Xml\Reader\Reader;
+use function Psl\Vec\map;
 use function VeeWee\Xml\Reader\Configurator\substitute_entities;
 use function VeeWee\Xml\Reader\Matcher\node_name;
 
@@ -21,11 +23,11 @@ final class SubstituteEntitiesTest extends TestCase
             [
                 '<user>my entity value</user>',
             ],
-            [...$iterator]
+            map($iterator, static fn (MatchingNode $match): string => $match->xml())
         );
     }
 
-    
+
     public function test_it_can_skip_substituting_entities(): void
     {
         $xml = $this->buildXml();
@@ -36,7 +38,7 @@ final class SubstituteEntitiesTest extends TestCase
             [
                 '<user>&entity;</user>',
             ],
-            [...$iterator]
+            map($iterator, static fn (MatchingNode $match): string => $match->xml())
         );
     }
 

--- a/tests/Xml/Reader/Configurator/XsdSchemaTest.php
+++ b/tests/Xml/Reader/Configurator/XsdSchemaTest.php
@@ -7,8 +7,10 @@ namespace VeeWee\Tests\Xml\Reader\Configurator;
 use PHPUnit\Framework\TestCase;
 use VeeWee\Tests\Xml\Helper\FillFileTrait;
 use VeeWee\Xml\Exception\RuntimeException;
+use VeeWee\Xml\Reader\MatchingNode;
 use VeeWee\Xml\Reader\Reader;
 use XMLReader;
+use function Psl\Vec\map;
 use function VeeWee\Xml\Reader\Configurator\xsd_schema;
 use function VeeWee\Xml\Reader\Matcher\node_name;
 
@@ -16,7 +18,7 @@ final class XsdSchemaTest extends TestCase
 {
     use FillFileTrait;
 
-    
+
     public function test_it_can_iterate_if_the_schema_matches(): void
     {
         [$xsdFile, $xsdHandle] = $this->createXsdFile();
@@ -37,13 +39,13 @@ final class XsdSchemaTest extends TestCase
                 '<user>Bos</user>',
                 '<user>Mos</user>'
             ],
-            [...$iterator]
+            map($iterator, static fn (MatchingNode $match): string => $match->xml())
         );
 
         fclose($xsdHandle);
     }
 
-    
+
     public function test_it_triggers_an_error_on_invalid_schema(): void
     {
         [$xsdFile, $xsdHandle] = $this->createXsdFile();
@@ -65,7 +67,7 @@ final class XsdSchemaTest extends TestCase
         fclose($xsdHandle);
     }
 
-    
+
     public function test_it_triggers_an_error_if_schema_file_does_not_exist(): void
     {
         $xml = '<root />';
@@ -80,7 +82,7 @@ final class XsdSchemaTest extends TestCase
         fclose($xsdHandle);
     }
 
-    
+
     public function test_it_can_not_set_a_schema_if_the_reader_started_reading(): void
     {
         [$xsdFile, $xsdHandle] = $this->createXsdFile();
@@ -93,7 +95,7 @@ final class XsdSchemaTest extends TestCase
         fclose($xsdHandle);
     }
 
-    
+
     public function test_it_can_not_set_a_schema_if_the_schema_is_invalid(): void
     {
         [$xsdFile, $xsdHandle] = $this->fillFile('invalid schema');

--- a/tests/Xml/Reader/Matcher/AbstractMatcherTest.php
+++ b/tests/Xml/Reader/Matcher/AbstractMatcherTest.php
@@ -6,8 +6,10 @@ namespace VeeWee\Tests\Xml\Reader\Matcher;
 use Closure;
 use Generator;
 use PHPUnit\Framework\TestCase;
+use VeeWee\Xml\Reader\MatchingNode;
 use VeeWee\Xml\Reader\Node\NodeSequence;
 use VeeWee\Xml\Reader\Reader;
+use function Psl\Vec\map;
 
 abstract class AbstractMatcherTest extends TestCase
 {
@@ -23,7 +25,7 @@ abstract class AbstractMatcherTest extends TestCase
     public function test_real_xml_cases(Closure $matcher, string $xml, array $expected)
     {
         $reader = Reader::fromXmlString($xml);
-        $actual = [...$reader->provide($matcher)];
+        $actual = map($reader->provide($matcher), static fn (MatchingNode $match): string => $match->xml());
 
         static::assertSame($actual, $expected);
     }

--- a/tests/Xml/Reader/MatchingNodeTest.php
+++ b/tests/Xml/Reader/MatchingNodeTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Reader;
+
+use PHPUnit\Framework\TestCase;
+use VeeWee\Xml\Reader\MatchingNode;
+use VeeWee\Xml\Reader\Node\ElementNode;
+use VeeWee\Xml\Reader\Node\NodeSequence;
+use function Psl\Fun\identity;
+use function VeeWee\Xml\Dom\Locator\document_element;
+use function VeeWee\Xml\Dom\Mapper\xml_string;
+use function VeeWee\Xml\Reader\Matcher\element_name;
+
+final class MatchingNodeTest extends TestCase
+{
+
+    public function test_it_is_a_matching_node(): void
+    {
+        $match = new MatchingNode(
+            $xml = '<hello/>',
+            $sequence = new NodeSequence(
+                new ElementNode(1, 'hello', 'hello', '', '', [])
+            )
+        );
+
+        static::assertSame($xml, $match->xml());
+        static::assertSame($sequence, $match->nodeSequence());
+    }
+
+
+    public function test_it_can_match(): void
+    {
+        $match = new MatchingNode(
+            '<hello/>',
+            new NodeSequence(
+                new ElementNode(1, 'hello', 'hello', '', '', [])
+            )
+        );
+
+        static::assertTrue($match->matches(element_name('hello')));
+        static::assertFalse($match->matches(element_name('world')));
+    }
+
+
+    public function test_it_can_transform_into_a_dom_document(): void
+    {
+        $match = new MatchingNode(
+            $xml = '<hello/>',
+            new NodeSequence(
+                new ElementNode(1, 'hello', 'hello', '', '', [])
+            )
+        );
+
+        $document = $match->intoDocument(identity());
+
+        static::assertSame($xml, xml_string()($document->map(document_element())));
+    }
+
+    public function test_it_can_decode_the_xml(): void
+    {
+        $match = new MatchingNode(
+            $xml = '<hello/>',
+            new NodeSequence(
+                new ElementNode(1, 'hello', 'hello', '', '', [])
+            )
+        );
+
+        $decoded = $match->decode(identity());
+
+        static::assertSame(['hello' => ''], $decoded);
+    }
+}

--- a/tests/Xml/Reader/SignalTest.php
+++ b/tests/Xml/Reader/SignalTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace VeeWee\Tests\Xml\Reader;
+
+use PHPUnit\Framework\TestCase;
+use VeeWee\Xml\Reader\Signal;
+
+final class SignalTest extends TestCase
+{
+    
+    public function test_it_can_signal_a_stop_command(): void
+    {
+        $signal = new Signal();
+        static::assertFalse($signal->stopRequested());
+
+        $signal->stop();
+        static::assertTrue($signal->stopRequested());
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | #58

#### Summary

❗ This is a BC break and should be released in a new major version ❗ 

```php
use VeeWee\Xml\Dom\Configurator;
use VeeWee\Xml\Reader\Signal;
use function VeeWee\Xml\Reader\Matcher\element_name;
use function VeeWee\Xml\Reader\Matcher\sequence;


$xml = <<<XML
    <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
      <services>
        <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
        <service id="kernel" class="TicketSwap\Kernel" public="true" synthetic="true" autoconfigure="true">
          <tag xmlns="http://symfony.com/schema/dic/tag-1" name="controller.service_arguments">1</tag>
          <tag xmlns="http://symfony.com/schema/dic/tag-2"  name="routing.route_loader">2</tag>
        </service>
      </services>
    </container>
XML;


$reader = VeeWee\Xml\Reader\Reader::fromXmlString($xml);
$signal = new Signal();

foreach ($reader->provide(element_name('tag'), $signal) as $tag) {
    // New result of the reader is now a DTO that contains both the XML and node sequence.
    var_dump(
    // This is the previous matched XML `string`
        $tag->xml(),
        // Contains a match function so that you can run a secondary matcher on the result.
        // Can be handy if you are matching on multiple paths in one read for example.
        $tag->matches(sequence(
                element_name('container'),
                element_name('services'),
                element_name('service'),
                element_name('tag')
        )),
        // You can now directly pull the xml into a DOM Document with or without a DOM configurator.
        $tag->intoDocument(Configurator\canonicalize()),
        // Or decode it directly using xml_decode:
        $tag->decode(Configurator\canonicalize()),
        // You can get access to the current matching NodeSequence data:
        $tag->nodeSequence(),
    );

    // Stops reading on first `tag` match.
    $signal->stop();
}

```