### PR TITLE
Allow `webmozart/assert` at version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-xmlreader": "*",
         "ext-xmlwriter": "*",
         "azjezz/psl": "^3.0 || ~4.0",
-        "webmozart/assert": "^1.10"
+        "webmozart/assert": "^1.10|^2.0"
     },
     "require-dev": {
         "symfony/finder": "^7.1",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Declared compatible with `webmozart/assert:~2.0`

#### Summary

Change the version requirements for this package.