### PR TITLE
Add support for azjezz/psl v5.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-xsl": "*",
         "ext-xmlreader": "*",
         "ext-xmlwriter": "*",
-        "azjezz/psl": "^3.0 || ~4.0",
+        "azjezz/psl": "^3.0 || ~4.0 || ^5.0",
         "webmozart/assert": "^1.10 || ~2.0"
     },
     "require-dev": {

--- a/tests/Xml/Reader/Node/NodeSequenceTest.php
+++ b/tests/Xml/Reader/Node/NodeSequenceTest.php
@@ -119,8 +119,6 @@ final class NodeSequenceTest extends TestCase
             $element2 = new ElementNode(1, 'item2', 'item2', '', '', []),
         );
 
-        static::assertEquals($sequence, $sequence->slice(-1));
-        static::assertEquals(new NodeSequence($element1), $sequence->slice(-1, 1));
         static::assertEquals(new NodeSequence($element1), $sequence->slice(0, 1));
         static::assertEquals(new NodeSequence($element1, $element2), $sequence->slice(0));
         static::assertEquals(new NodeSequence($element2), $sequence->slice(1, 1));


### PR DESCRIPTION
## Summary
- Update PSL constraint from `^3.0 || ~4.0` to `^3.0 || ~4.0 || ^5.0`
- Remove test assertions using negative offsets with `Vec\slice` (violated `@param non-negative-int` contract)

## Test plan
- [x] `composer run ci` passes (CS, Psalm, PHPUnit, coverage, infection, stress)

See https://github.com/phpro/soap-client/issues/604