### PR TITLE
Add support for azjezz/psl v5.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-xsl": "*",
         "ext-xmlreader": "*",
         "ext-xmlwriter": "*",
-        "azjezz/psl": "^3.0 || ^4.0",
+        "azjezz/psl": "^3.0 || ^4.0 || ^5.0",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {

--- a/tests/Xml/Dom/Loader/XmlFileLoaderTest.php
+++ b/tests/Xml/Dom/Loader/XmlFileLoaderTest.php
@@ -60,7 +60,7 @@ final class XmlFileLoaderTest extends TestCase
         $loader = xml_file_loader('invalid-file');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The file "invalid-file" does not exist');
+        $this->expectExceptionMessage('"invalid-file" does not exist');
 
         $loader($doc);
     }

--- a/tests/Xml/Reader/Configurator/XsdSchemaTest.php
+++ b/tests/Xml/Reader/Configurator/XsdSchemaTest.php
@@ -76,7 +76,7 @@ final class XsdSchemaTest extends TestCase
         $iterator = $reader->provide(element_name('user'));
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The file "unkown-file" does not exist.');
+        $this->expectExceptionMessage('"unkown-file" does not exist');
         [...$iterator];
 
         fclose($xsdHandle);

--- a/tests/Xml/Reader/Loader/XmlFileLoaderTest.php
+++ b/tests/Xml/Reader/Loader/XmlFileLoaderTest.php
@@ -17,7 +17,7 @@ final class XmlFileLoaderTest extends TestCase
     public function test_it_invalid_file_loader(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The file "invalid-file" does not exist.');
+        $this->expectExceptionMessage('"invalid-file" does not exist');
 
         xml_file_loader('invalid-file')();
     }

--- a/tests/Xml/Reader/Node/NodeSequenceTest.php
+++ b/tests/Xml/Reader/Node/NodeSequenceTest.php
@@ -119,8 +119,6 @@ final class NodeSequenceTest extends TestCase
             $element2 = new ElementNode(1, 'item2', 'item2', '', '', []),
         );
 
-        static::assertEquals($sequence, $sequence->slice(-1));
-        static::assertEquals(new NodeSequence($element1), $sequence->slice(-1, 1));
         static::assertEquals(new NodeSequence($element1), $sequence->slice(0, 1));
         static::assertEquals(new NodeSequence($element1, $element2), $sequence->slice(0));
         static::assertEquals(new NodeSequence($element2), $sequence->slice(1, 1));

--- a/tests/Xml/Xslt/Configurator/ProfilerTest.php
+++ b/tests/Xml/Xslt/Configurator/ProfilerTest.php
@@ -35,7 +35,7 @@ final class ProfilerTest extends TestCase
     public function test_setting_an_invalid_profiler_location_doesnt_result(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The file "/THISFOLDERSHOULDNOTEXIST" does not exist.');
+        $this->expectExceptionMessage('/THISFOLDERSHOULDNOTEXIST');
 
         Processor::fromTemplateDocument(
             $this->createTemplate(),


### PR DESCRIPTION
## Summary
- Update PSL constraint from `^3.0 || ^4.0` to `^3.0 || ^4.0 || ^5.0`
- Remove test assertions using negative offsets with `Vec\slice` (violated `@param non-negative-int` contract)
- Relax exception message assertions to accommodate PSL v5 wording changes ("path" instead of "file")

## Test plan
- [x] `composer run ci` passes (CS, Psalm, PHPUnit, coverage, infection, stress)


See https://github.com/phpro/soap-client/issues/604