### PR TITLE
Replace abandoned azjezz/psl with php-standard-library/php-standard-library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-xsl": "*",
         "ext-xmlreader": "*",
         "ext-xmlwriter": "*",
-        "azjezz/psl": "^3.0 || ^4.0 || ^5.0",
+        "php-standard-library/php-standard-library": "^3.0 || ~4.0 || ^5.0 || ^6.0",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -206,7 +206,7 @@ $data = typed(
 ```
 
 It works exactly the same as the [xml_decode](#xml_decode) function but with an additional type parameter.
-Structuring the shape of the type-result is done by the [azjezz/psl](https://github.com/azjezz/psl) package.
+Structuring the shape of the type-result is done by the [php-standard-library/php-standard-library](https://github.com/php-standard-library/php-standard-library) package.
 
 In modern systems, you might find the need to convert XML data to DTO objects.
 You can do so by using the typed class as well:


### PR DESCRIPTION
## Summary
- Replaces the abandoned `azjezz/psl` package with `php-standard-library/php-standard-library`
- Allows version ranges `^3.0 || ~4.0 || ^5.0 || ^6.0`

Closes #97