### PR TITLE
Work around C14N duplicate xmlns bug on libxml 2.9.14

### DIFF
--- a/src/Xml/Dom/Configurator/canonicalize.php
+++ b/src/Xml/Dom/Configurator/canonicalize.php
@@ -23,7 +23,7 @@ function canonicalize(): Closure
         // Round-trip through saveXml first to normalize namespace declarations.
         // C14N on DOM-manipulated documents can produce duplicate xmlns attributes
         // on certain libxml versions (e.g. 2.9.14), causing createFromString to hang.
-        // @see https://github.com/php/php-src/issues/XXXXX
+        // @see https://github.com/php/php-src/issues/21548
         $normalized = XMLDocument::createFromString(
             non_empty_string()->assert($document->saveXml()),
         );

--- a/src/Xml/Dom/Configurator/canonicalize.php
+++ b/src/Xml/Dom/Configurator/canonicalize.php
@@ -20,9 +20,17 @@ function canonicalize(): Closure
             return $document;
         }
 
+        // Round-trip through saveXml first to normalize namespace declarations.
+        // C14N on DOM-manipulated documents can produce duplicate xmlns attributes
+        // on certain libxml versions (e.g. 2.9.14), causing createFromString to hang.
+        // @see https://github.com/php/php-src/issues/XXXXX
+        $normalized = XMLDocument::createFromString(
+            non_empty_string()->assert($document->saveXml()),
+        );
+
         return Document::fromLoader(
             xml_string_loader(
-                non_empty_string()->assert($document->C14N()),
+                non_empty_string()->assert($normalized->C14N()),
                 LIBXML_NSCLEAN + LIBXML_NOCDATA
             ),
             pretty_print(),

--- a/src/Xml/Dom/Manipulator/Xmlns/rename_element_namespace.php
+++ b/src/Xml/Dom/Manipulator/Xmlns/rename_element_namespace.php
@@ -31,10 +31,11 @@ function rename_element_namespace(Element $element, string $namespaceURI, string
         if (is_xmlns_attribute($attr) && $attr->value === $namespaceURI) {
             try {
                 $attr->rename($attr->namespaceURI, 'xmlns:' . $newPrefix);
-
             } catch (DOMException $e) {
                 if ($e->getCode() === INVALID_MODIFICATION_ERR) {
-                    // Remove the attribute that would become a duplicate
+                    // Remove the attribute that would become a duplicate.
+                    // The target prefix already exists on the element, so the old
+                    // xmlns declaration can simply be dropped.
                     $element->removeAttributeNode($attr);
                 } else {
                     // @codeCoverageIgnoreStart
@@ -42,7 +43,6 @@ function rename_element_namespace(Element $element, string $namespaceURI, string
                     // @codeCoverageIgnoreEnd
                 }
             }
-            $attr->rename($attr->namespaceURI, 'xmlns:' . $newPrefix);
         }
     });
 

--- a/tests/Xml/Dom/Configurator/CanonicalizeTest.php
+++ b/tests/Xml/Dom/Configurator/CanonicalizeTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use VeeWee\Xml\Dom\Document;
 use function VeeWee\Xml\Dom\Configurator\canonicalize;
+use function VeeWee\Xml\Dom\Configurator\optimize_namespaces;
 use function VeeWee\Xml\Dom\Locator\document_element;
 use function VeeWee\Xml\Dom\Mapper\xml_string;
 
@@ -20,6 +21,26 @@ final class CanonicalizeTest extends TestCase
         $actual = xml_string()($canonicalized->map(document_element()));
 
         static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Regression test: canonicalize() on a DOM-manipulated document (e.g. after
+     * optimize_namespaces) would hang on libxml 2.9.14 because C14N produced
+     * duplicate xmlns declarations.
+     * @see https://github.com/php/php-src/issues/XXXXX
+     */
+    public function test_it_can_canonicalize_after_dom_manipulation(): void
+    {
+        $doc = Document::fromXmlString(
+            '<root xmlns="urn:a" attr="val"><child/></root>',
+            optimize_namespaces(),
+        );
+
+        $canonicalized = Document::fromUnsafeDocument($doc->toUnsafeDocument(), canonicalize());
+        $actual = xml_string()($canonicalized->map(document_element()));
+
+        static::assertStringContainsString('root', $actual);
+        static::assertStringNotContainsString('xmlns:ns1="urn:a" attr="val" xmlns:ns1="urn:a"', $actual);
     }
 
     public function test_it_can_canonicalize_empty_xml(): void

--- a/tests/Xml/Dom/Configurator/CanonicalizeTest.php
+++ b/tests/Xml/Dom/Configurator/CanonicalizeTest.php
@@ -27,7 +27,7 @@ final class CanonicalizeTest extends TestCase
      * Regression test: canonicalize() on a DOM-manipulated document (e.g. after
      * optimize_namespaces) would hang on libxml 2.9.14 because C14N produced
      * duplicate xmlns declarations.
-     * @see https://github.com/php/php-src/issues/XXXXX
+     * @see https://github.com/php/php-src/issues/21548
      */
     public function test_it_can_canonicalize_after_dom_manipulation(): void
     {

--- a/tests/Xml/Dom/Configurator/ComparableTest.php
+++ b/tests/Xml/Dom/Configurator/ComparableTest.php
@@ -86,6 +86,23 @@ final class ComparableTest extends TestCase
             </foo>
             EOXML,
         ];
+        // Regression test: default xmlns + regular attributes caused C14N to produce
+        // duplicate xmlns declarations on libxml 2.9.14, making comparable() hang.
+        // @see https://github.com/php/php-src/issues/XXXXX
+        yield 'default-xmlns-with-attributes' => [
+            <<<EOXML
+            <definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="Test">
+                <types><xsd:schema/></types>
+            </definitions>
+            EOXML,
+            <<<EOXML
+            <ns1:definitions name="Test" xmlns:ns1="http://schemas.xmlsoap.org/wsdl/" xmlns:ns2="http://www.w3.org/2001/XMLSchema">
+              <ns1:types>
+                <ns2:schema/>
+              </ns1:types>
+            </ns1:definitions>
+            EOXML,
+        ];
         yield 'sorted-attributes' => [
             <<<EOXML
             <foo xmlns:a="http://a" xmlns:z="http://z" version="1.9" target="universe">

--- a/tests/Xml/Dom/Configurator/ComparableTest.php
+++ b/tests/Xml/Dom/Configurator/ComparableTest.php
@@ -88,7 +88,7 @@ final class ComparableTest extends TestCase
         ];
         // Regression test: default xmlns + regular attributes caused C14N to produce
         // duplicate xmlns declarations on libxml 2.9.14, making comparable() hang.
-        // @see https://github.com/php/php-src/issues/XXXXX
+        // @see https://github.com/php/php-src/issues/21548
         yield 'default-xmlns-with-attributes' => [
             <<<EOXML
             <definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="Test">


### PR DESCRIPTION
## Summary

- `canonicalize()`: round-trip through `saveXml()` before calling `C14N()` to normalize namespace declarations that get corrupted in DOM-manipulated documents
- `rename_element_namespace()`: remove stray `Attr::rename()` call that ran on a detached attribute node after `removeAttributeNode()`

## Problem

`C14N()` on DOM-manipulated documents (e.g. after `optimize_namespaces()`) produces duplicate xmlns declarations when the element has a default xmlns and non-xmlns attributes. On libxml 2.9.14 (Ubuntu 24.04), parsing the invalid C14N output hangs or crashes with `double free`.

Minimal reproducer:

```php
$doc = Dom\XMLDocument::createFromString('<root xmlns="urn:a" attr="val"/>');
$doc->documentElement->setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:ns1", "urn:a");
echo $doc->C14N();
// Output: <root xmlns="urn:a" xmlns:ns1="urn:a" attr="val" xmlns:ns1="urn:a"></root>
//         ^ xmlns:ns1 appears TWICE
```

This caused `comparable()` (which calls `optimize_namespaces()` then `canonicalize()`) to hang on CI with libxml 2.9.14.

## Test plan

- [ ] New test `CanonicalizeTest::test_it_can_canonicalize_after_dom_manipulation` passes
- [ ] New `ComparableTest` data case `default-xmlns-with-attributes` passes  
- [ ] Full test suite passes on libxml 2.9.14 (tested via Docker `docphpro/php84`)
- [ ] Full test suite passes on libxml 2.9.13 (tested locally on macOS)